### PR TITLE
Add ability to store email logs in a separate connection/database

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Run the migration
 $ php artisan migrate
 ```
 
+Note: If you would like to use a different connection to store your models, 
+you should update the mail-tracker.php config entry ```connection``` before running the migrations. 
+
 ## Install (Lumen)
 
 Via Composer
@@ -67,6 +70,9 @@ Run the migration
 ``` bash
 $ php artisan migrate
 ```
+
+Note: If you would like to use a different connection to store your models, 
+you should update the mail-tracker.php config entry ```connection``` before running the migrations.
 
 ## Usage
 

--- a/config/mail-tracker.php
+++ b/config/mail-tracker.php
@@ -54,4 +54,9 @@ return [
      */
     'date-format' => 'm/d/Y g:i a',
 
+    /**
+     * Default database connection name (optional - use null for default)
+     */
+    'connection' => null
+
 ];

--- a/database/migrations/2016_03_01_193027_create_sent_emails_table.php
+++ b/database/migrations/2016_03_01_193027_create_sent_emails_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use jdavidbakr\MailTracker\Model\SentEmail;
 
 class CreateSentEmailsTable extends Migration
 {
@@ -12,7 +13,7 @@ class CreateSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::create('sent_emails', function (Blueprint $table) {
+        Schema::connection((new SentEmail)->getConnectionName())->create('sent_emails', function (Blueprint $table) {
             $table->increments('id');
             $table->char('hash',32)->unique();
             $table->text('headers')->nullable();
@@ -33,6 +34,6 @@ class CreateSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('sent_emails');
+        Schema::connection((new SentEmail())->getConnectionName())->drop('sent_emails');
     }
 }

--- a/database/migrations/2016_09_07_193027_create_sent_emails_Url_Clicked_table.php
+++ b/database/migrations/2016_09_07_193027_create_sent_emails_Url_Clicked_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
 
 class CreateSentEmailsUrlClickedTable extends Migration
 {
@@ -12,7 +13,7 @@ class CreateSentEmailsUrlClickedTable extends Migration
      */
     public function up()
     {
-        Schema::create('sent_emails_url_clicked', function (Blueprint $table) {
+        Schema::connection((new SentEmailUrlClicked())->getConnectionName())->create('sent_emails_url_clicked', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('sent_email_id')->unsigned();
             $table->foreign('sent_email_id')->references('id')->on('sent_emails')->onDelete('cascade');
@@ -30,6 +31,6 @@ class CreateSentEmailsUrlClickedTable extends Migration
      */
     public function down()
     {
-        Schema::drop('sent_emails_url_clicked');
+        Schema::connection((new SentEmailUrlClicked())->getConnectionName())->drop('sent_emails_url_clicked');
     }
 }

--- a/database/migrations/2016_11_10_213551_add-message-id-to-sent-emails-table.php
+++ b/database/migrations/2016_11_10_213551_add-message-id-to-sent-emails-table.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use jdavidbakr\MailTracker\Model\SentEmail;
 
 class AddMessageIdToSentEmailsTable extends Migration
 {
@@ -13,7 +14,7 @@ class AddMessageIdToSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::table('sent_emails', function(Blueprint $table) {
+        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function(Blueprint $table) {
             $table->string('message_id')->nullable();
             $table->text('meta')->default('[]');
         });
@@ -26,7 +27,7 @@ class AddMessageIdToSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::table('sent_emails', function(Blueprint $table) {
+        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function(Blueprint $table) {
             $table->dropColumn('message_id');
             $table->dropColumn('meta');
         });

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -23,6 +23,12 @@ class SentEmail extends Model
         'meta'=>'collection',
     ];
 
+    public function getConnectionName()
+    {
+        $connName = config('mail-tracker.connection');
+        return $connName ?: config('database.default');
+    }
+
     /**
      * Returns a bootstrap class about the success/failure of the message
      * @return [type] [description]

--- a/src/Model/SentEmailUrlClicked.php
+++ b/src/Model/SentEmailUrlClicked.php
@@ -16,6 +16,12 @@ class SentEmailUrlClicked extends Model
     	'clicks',
     ];
 
+    public function getConnectionName()
+    {
+        $connName = config('mail-tracker.connection');
+        return $connName ?: config('database.default');
+    }
+
     public function email()
     {
       return $this->belongsTo(SentEmail::class,'sent_email_id');

--- a/tests/MailTrackerTest.php
+++ b/tests/MailTrackerTest.php
@@ -47,6 +47,11 @@ class AddressVerificationTest extends TestCase
 	        'database' => ':memory:',
 	        'prefix'   => '',
 	    ]);
+	    $app['config']->set('database.connections.secondary', [
+	        'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => ''
+        ]);
 	    $app['config']->set('aws.credentials', [
 	        'key'    => env('AWS_ACCESS_KEY_ID'),
 	        'secret' => env('AWS_SECRET_ACCESS_KEY')
@@ -421,5 +426,61 @@ class AddressVerificationTest extends TestCase
 		$track = \jdavidbakr\MailTracker\Model\SentEmail::orderBy('id','desc')->first();
 		$this->assertEquals($header_test, $track->getHeader('X-Header-Test'));
 	}
+
+    /**
+     * @test
+     */
+    public function it_handles_secondary_connection()
+    {
+        // Create an old email to purge
+        Config::set('mail-tracker.expire-days', 1);
+
+        Config::set('mail-tracker.connection', 'secondary');
+        $this->app['migrator']->setConnection('secondary');
+        $this->artisan('migrate', ['--database' => 'secondary']);
+
+        $old_email = \jdavidbakr\MailTracker\Model\SentEmail::create([
+            'hash'=>str_random(32),
+        ]);
+        $old_url = \jdavidbakr\MailTracker\Model\SentEmailUrlClicked::create([
+            'sent_email_id'=>$old_email->id,
+            'hash'=>str_random(32),
+        ]);
+        // Go into the future to make sure that the old email gets removed
+        \Carbon\Carbon::setTestNow(\Carbon\Carbon::now()->addWeek());
+
+        Event::fake();
+
+        $faker = Faker\Factory::create();
+        $email = $faker->email;
+        $subject = $faker->sentence;
+        $name = $faker->firstName . ' ' .$faker->lastName;
+        \View::addLocation(__DIR__);
+        \Mail::send('email.test', [], function ($message) use($email, $subject, $name) {
+            $message->from('from@johndoe.com', 'From Name');
+            $message->sender('sender@johndoe.com', 'Sender Name');
+
+            $message->to($email, $name);
+
+            $message->cc('cc@johndoe.com', 'CC Name');
+            $message->bcc('bcc@johndoe.com', 'BCC Name');
+
+            $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
+
+            $message->subject($subject);
+
+            $message->priority(3);
+        });
+
+        Event::assertDispatched(jdavidbakr\MailTracker\Events\EmailSentEvent::class);
+
+        $this->seeInDatabase('sent_emails',[
+            'recipient'=>$name.' <'.$email.'>',
+            'subject'=>$subject,
+            'sender'=>'From Name <from@johndoe.com>'
+        ],'secondary');
+        $this->assertNull($old_email->fresh());
+        $this->assertNull($old_url->fresh());
+    }
 }
 


### PR DESCRIPTION
Adds a config option to specify the connection name to use (null for default)

I don't want to clutter my relational database and inflate my backups with the email logs, so I created a way to specify which connection to write them to.