### PR TITLE
Fix case when HTML encoded ampersand is included in the email's URL (redirect issue)

### DIFF
--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -92,7 +92,7 @@ class MailTracker implements \Swift_Events_SendListener {
         if (empty($matches[2])) {
             $url = app()->make('url')->to('/');
         } else {
-            $url = $matches[2];
+            $url = str_replace('&amp;', '&', $matches[2]);
         }
 
     	return $matches[1].route('mailTracker_l',

--- a/tests/email/testAmpersand.blade.php
+++ b/tests/email/testAmpersand.blade.php
@@ -1,0 +1,17 @@
+<head>
+    This is the head
+</head>
+<body>
+<h1>
+    This is a test!
+</h1>
+<p>
+    Please
+    <a href="http://www.google.com">Click Here</a>
+</p>
+<p>
+    <a class="test" href="http://www.google.com?q=foo&amp;x=bar">
+        Click here, too.
+    </a>
+</p>
+</body>


### PR DESCRIPTION
There is an issue when an HTML encoded ampersand (```&amp;```) is included in an email's markup. The link redirector would redirect to the ampersand encoded url in PHP, which would essentially append a literal ampersand (and everything after it) to the previous query string parameter.  A bit hard to explain, but I've changed it so the url should be stored in the database with the ```&amp;``` and therefore when retrieved and redirected it will redirect with all parameters in the URL bar.

Also, the test I added should be a bit more end-to-end by actually sending it through the Mail's ```array``` engine, and verifying the transformed body after sending through the plugin.