### PR TITLE
Stop red cross appearing in Outlook when auto download images is off

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MailTracker will hook into all outgoing emails from Laravel/Lumen and inject a t
 First, upgrade to version 2.1 by running:
 
 ``` bash
-$ composer require maltonite/mail-tracker-1
+$ composer require jdavidbakr/mail-tracker ~2.1
 ```
 
 If you are updating from an earlier version, you will need to update the config file and run the new migrations.  For best results, make a backup copy of config/mail-tracker.php and the views in resources/views/vendor/emailTrackingViews (if they exists) to restore any values you have customized, then delete that file and run

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MailTracker will hook into all outgoing emails from Laravel/Lumen and inject a t
 First, upgrade to version 2.1 by running:
 
 ``` bash
-$ composer require jdavidbakr/mail-tracker ~2.1
+$ composer require maltonite/mail-tracker-1
 ```
 
 If you are updating from an earlier version, you will need to update the config file and run the new migrations.  For best results, make a backup copy of config/mail-tracker.php and the views in resources/views/vendor/emailTrackingViews (if they exists) to restore any values you have customized, then delete that file and run

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -61,13 +61,13 @@ class MailTracker implements \Swift_Events_SendListener {
     protected function injectTrackingPixel($html, $hash)
     {
     	// Append the tracking url
-    	$tracking_pixel = '<img src="'.route('mailTracker_t',[$hash]).'" />';
+    	$tracking_pixel = '<img border=0 width=1 alt="" height=1 src="'.route('mailTracker_t',[$hash]).'" />';
 
     	$linebreak = str_random(32);
     	$html = str_replace("\n",$linebreak,$html);
 
     	if(preg_match("/^(.*<body[^>]*>)(.*)$/", $html, $matches)) {
-    		$html = $matches[1].$tracking_pixel.$matches[2];
+    		$html = $matches[1].$matches[2].$tracking_pixel;
     	} else {
     		$html = $html . $tracking_pixel;
     	}


### PR DESCRIPTION
In Outlook, there is an issue that a red cross is shown before images are downloaded.

Two changes:
1. Now specifying the border, size and alt-text of the pixel.
2. Placing the pixel at the end of the body. This has the benefit of it not stopping the first line of text appearing when a new email notification pops up.