### PR TITLE
added configuration option to prevent logging body to sent_emails

### DIFF
--- a/config/mail-tracker.php
+++ b/config/mail-tracker.php
@@ -62,6 +62,11 @@ return [
     /**
      * The SNS notification topic - if set, discard all notifications not in this topic.
      */
-    'sns-topic' => null
+    'sns-topic' => null,
+
+    /**
+     * Determines whether or not the body of the email is logged in the sent_emails table
+     */
+    'log-content' => true
 
 ];

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -152,7 +152,7 @@ class MailTracker implements \Swift_Events_SendListener {
                     'sender'=>$from_name." <".$from_email.">",
                     'recipient'=>$to_name.' <'.$to_email.'>',
                     'subject'=>$subject,
-                    'content'=>$original_content,
+                    'content'=> config('mail-tracker.log-content', true) ? (strlen($original_content) > 65535 ? substr($original_content, 0, 65532) . "..." : $original_content) : null,
                     'opens'=>0,
                     'clicks'=>0,
                     'message_id'=>$message->getId(),


### PR DESCRIPTION
Also added a failsafe so that if you do log the email body (default behaviour) but the body is more than 65535 characters long then it will truncate and avoid the fatal error