### PR TITLE
Fires distinct events for complaint, bounce and delivered emails afte…

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ When an email is sent, viewed, or a link is clicked, its tracking information is
 -   jdavidbakr\MailTracker\Events\ViewEmailEvent
 -   jdavidbakr\MailTracker\Events\LinkClickedEvent
 
-If you are using the Amazon SNS notification system, an event is fired when you receive a permanent bounce. You may want to mark the email as bad or remove it from your database.
-
--   jdavidbakr\MailTracker\Events\PermanentBouncedMessageEvent
+If you are using the Amazon SNS notification system, these events are fired so you can do additional processing.
+-   jdavidbakr\MailTracker\Events\EmailDeliveredEvent (when you received a "message delivered" event, you may want to mark the email as "good" or "delivered" in your database)
+-   jdavidbakr\MailTracker\Events\ComplaintMessageEvent (when you received a complaint, ex: marked as "spam", you may want to remove the email from your database)
+-   jdavidbakr\MailTracker\Events\PermanentBouncedMessageEvent (when you receive a permanent bounce, you may want to mark the email as bad or remove it from your database)
 
 To install an event listener, you will want to create a file like the following:
 
@@ -155,7 +156,7 @@ class BouncedEmail
 }
 ```
 
-Then you must register the event in your \App\Providers\EventServiceProvider \$listen array:
+Then you must register the events you want to act on in your \App\Providers\EventServiceProvider \$listen array:
 
 ```php
 /**
@@ -164,8 +165,20 @@ Then you must register the event in your \App\Providers\EventServiceProvider \$l
  * @var array
  */
 protected $listen = [
+    'jdavidbakr\MailTracker\Events\EmailSentEvent' => [
+        'App\Listeners\EmailSent',
+    ],
     'jdavidbakr\MailTracker\Events\ViewEmailEvent' => [
         'App\Listeners\EmailViewed',
+    ],
+    'jdavidbakr\MailTracker\Events\LinkClickedEvent' => [
+        'App\Listeners\EmailLinkClicked',
+    ],
+    'jdavidbakr\MailTracker\Events\EmailDeliveredEvent' => [
+        'App\Listeners\EmailDelivered',
+    ],
+    'jdavidbakr\MailTracker\Events\ComplaintMessageEvent' => [
+        'App\Listeners\EmailComplaint',
     ],
     'jdavidbakr\MailTracker\Events\PermanentBouncedMessageEvent' => [
         'App\Listeners\BouncedEmail',

--- a/src/Events/ComplaintMessageEvent.php
+++ b/src/Events/ComplaintMessageEvent.php
@@ -5,7 +5,7 @@ namespace jdavidbakr\MailTracker\Events;
 use jdavidbakr\MailTracker\Model\SentEmail;
 use Illuminate\Queue\SerializesModels;
 
-class PermanentBouncedMessageEvent
+class ComplaintMessageEvent
 {
     use SerializesModels;
 

--- a/src/Events/EmailDeliveredEvent.php
+++ b/src/Events/EmailDeliveredEvent.php
@@ -5,7 +5,7 @@ namespace jdavidbakr\MailTracker\Events;
 use jdavidbakr\MailTracker\Model\SentEmail;
 use Illuminate\Queue\SerializesModels;
 
-class PermanentBouncedMessageEvent
+class EmailDeliveredEvent
 {
     use SerializesModels;
 

--- a/tests/MailTrackerTest.php
+++ b/tests/MailTrackerTest.php
@@ -669,7 +669,7 @@ class MailTrackerTest extends TestCase
         $track = $track->fresh();
         $meta = $track->meta;
         $this->assertFalse($meta->get('success'));
-        Event::assertDispatched(jdavidbakr\MailTracker\Events\PermanentBouncedMessageEvent::class, function ($event) {
+        Event::assertDispatched(jdavidbakr\MailTracker\Events\ComplaintMessageEvent::class, function ($event) {
             return $event->email_address == 'recipient@example.com';
         });
     }/** @noinspection ProblematicWhitespace */


### PR DESCRIPTION
- Fires distinct events for complaint, bounce and delivered emails after SNS notifications received
- Adds a breaking change (event name) when firing Complaint email SNS notifications (so I'd probably create a new release with a major version change instead of hacking and double-firing events)
- Fires bounce events with extra data (sent_email and email recipient).
- Stores the full SNS messages received (for bounce, delivery, complaint) in the sent_emails.meta field
- Better error handling (also tested): Fires events received from SNS, even if sent_email is not found in the DB
- Updated readme with more details
- Updated existing unit test
- Note: Tested extensively with real SNS notifications. No unit tests were run.

Note: The code in process_delivery(), process_bounce(), process_complaint() are assuming that each email was sent to ONE receipient. This may not be true.
For example you could do this:
```
    Mail::to("complaint@simulator.amazonses.com")
        ->cc(["success@simulator.amazonses.com", "bounce@simulator.amazonses.com"])
        ->send($message)
```
So we cannot set "success" to true or false, like we are now. What happens if one email receipient gets a successful delivery, and the other bounces, or complains? Then you have a race condition. Same with the other metadata. However, I am not going to touch that. For now, better to append the meta field with every SNS message that was received...so we have a record of every correspondence from SNS.
I'm not sure what a more elegant long-term fix is (ideally we would have separate entries in sent_emails for each email recipient, but I leave that to you). Also, feel free to add unit tests if you so choose, I couldn't get them to run.




Sample SNS logs:
```
[2019-11-03 05:46:49] local.EMERGENCY: {"place":2,"message":{"notificationType":"Delivery","mail":{"timestamp":"2019-11-03T05:46:45.603Z","source":"support@mydomain.com","sourceArn":"arn:aws:ses:us-west-2:753511209472:identity\/mydomain.com","sourceIp":"76.14.181.19","sendingAccountId":"753511209472","messageId":"0101016e2fcd2be3-e5aa8aa0-e34c-4efd-b16e-bdb2795b1921-000000","destination":["bounce@simulator.amazonses.com","complaint@simulator.amazonses.com","success@simulator.amazonses.com"]},"delivery":{"timestamp":"2019-11-03T05:46:46.985Z","processingTimeMillis":1382,"recipients":["complaint@simulator.amazonses.com","success@simulator.amazonses.com"],"smtpResponse":"250 2.6.0 Message received","remoteMtaIp":"34.235.192.246","reportingMTA":"a27-206.smtp-out.us-west-2.amazonses.com"}}}  

[2019-11-03 05:46:49] local.EMERGENCY: {"place":2,"message":{"notificationType":"Bounce","bounce":{"bounceType":"Permanent","bounceSubType":"General","bouncedRecipients":[{"emailAddress":"bounce@simulator.amazonses.com","action":"failed","status":"5.1.1","diagnosticCode":"smtp; 550 5.1.1 user unknown"}],"timestamp":"2019-11-03T05:46:47.072Z","feedbackId":"0101016e2fcd3168-0aedd039-fcbb-499f-aa32-d044b18711bc-000000","remoteMtaIp":"34.235.192.246","reportingMTA":"dsn; a27-206.smtp-out.us-west-2.amazonses.com"},"mail":{"timestamp":"2019-11-03T05:46:45.000Z","source":"support@mydomain.com","sourceArn":"arn:aws:ses:us-west-2:753511209472:identity\/mydomain.com","sourceIp":"76.14.181.19","sendingAccountId":"753511209472","messageId":"0101016e2fcd2be3-e5aa8aa0-e34c-4efd-b16e-bdb2795b1921-000000","destination":["complaint@simulator.amazonses.com","success@simulator.amazonses.com","bounce@simulator.amazonses.com"]}}}  

[2019-11-03 05:46:50] local.EMERGENCY: {"place":2,"message":{"notificationType":"Complaint","complaint":{"complaintSubType":null,"complainedRecipients":[{"emailAddress":"complaint@simulator.amazonses.com"}],"timestamp":"2019-11-03T05:46:46.000Z","feedbackId":"0101016e2fcd35b3-909cfd81-46a8-4d05-b0c4-e09e1369f126-000000","userAgent":"Amazon SES Mailbox Simulator","complaintFeedbackType":"abuse"},"mail":{"timestamp":"2019-11-03T05:46:41.000Z","source":"support@mydomain.com","sourceArn":"arn:aws:ses:us-west-2:753511209472:identity\/mydomain.com","sourceIp":"76.14.181.19","sendingAccountId":"753511209472","messageId":"0101016e2fcd2be3-e5aa8aa0-e34c-4efd-b16e-bdb2795b1921-000000","destination":["complaint@simulator.amazonses.com","success@simulator.amazonses.com","bounce@simulator.amazonses.com"]}}}  
```