### PR TITLE
Added ability to set custom content size limit from config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Once installed, all outgoing mail will be logged to the database. The following 
 -   **admin-route**: The route information for the admin. Set the prefix and middleware.
 -   **admin-template**: The params for the Admin Panel and Views. You can integrate your existing Admin Panel with the MailTracker admin panel.
 -   **date-format**: You can define the format to show dates in the Admin Panel.
+-   **content-max-size**: You can overwrite default maximum length limit for `content` database field. Do not forget update it's type from `text` if make it longer.
 
 If you do not wish to have an email tracked, then you can add the `X-No-Track` header to your message. Put any random string into this header to prevent the tracking from occurring. The header will be removed from the email prior to being sent.
 

--- a/config/mail-tracker.php
+++ b/config/mail-tracker.php
@@ -78,4 +78,8 @@ return [
      */
     'tracker-queue' => null,
 
+    /**
+     * Size limit for content length stored in database
+     */
+    'content-max-size' => 65535,
 ];

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -166,7 +166,7 @@ class MailTracker implements \Swift_Events_SendListener
                     'sender' => $from_name." <".$from_email.">",
                     'recipient' => $to_name.' <'.$to_email.'>',
                     'subject' => $subject,
-                    'content' => config('mail-tracker.log-content', true) ? (strlen($original_content) > 65535 ? substr($original_content, 0, 65532) . "..." : $original_content) : null,
+                    'content' => config('mail-tracker.log-content', true) ? (strlen($original_content) > config('mail-tracker.content-max-size', 65535) ? substr($original_content, 0, config('mail-tracker.content-max-size', 65535)) . '...' : $original_content) : null,
                     'opens' => 0,
                     'clicks' => 0,
                     'message_id' => $message->getId(),


### PR DESCRIPTION
Based on following issue:
https://github.com/jdavidbakr/mail-tracker/issues/124
In short, added ability to set bigger length for `content` field.