### PR TITLE
Filestystem Strategy & Mailable models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor
+storage
 setup-test-variables.sh
 .idea
 .php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,10 @@
         "aws/aws-sdk-php": "^3.133"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.0",
+        "phpunit/phpunit": "^9.0",
         "orchestra/testbench": "~5.0|~6.0",
-        "mockery/mockery": "^1.1"
+        "mockery/mockery": "^1.1",
+        "nunomaduro/collision": "^5.10"
     },
     "suggest": {
         "fedeisas/laravel-mail-css-inliner": "Automatically inlines CSS into all outgoing mail."
@@ -41,7 +42,7 @@
         }
     },
     "scripts": {
-        "test": "phpunit"
+        "test": "./vendor/bin/testbench package:test"
     },
     "extra": {
         "laravel": {

--- a/config/mail-tracker.php
+++ b/config/mail-tracker.php
@@ -79,6 +79,18 @@ return [
     'log-content' => true,
 
     /**
+     * Determines whether or not the body should be stored in a file instead of database
+     * Can be wither 'database' or 'filesystem'
+     */
+    'log-content-strategy' => 'database',
+
+    /**
+     * What filesystem we use for storing content html files
+     */
+    'tracker-filesystem' => null,
+    'tracker-filesystem-folder' => 'mail-tracker',
+
+    /**
      * What queue should we dispatch our tracking jobs to?  Null will use the default queue.
      */
     'tracker-queue' => null,

--- a/config/mail-tracker.php
+++ b/config/mail-tracker.php
@@ -1,5 +1,7 @@
 <?php
 
+use jdavidbakr\MailTracker\Model\SentEmail;
+
 return [
     /**
      * To disable the pixel injection, set this to false.
@@ -94,6 +96,11 @@ return [
      * What queue should we dispatch our tracking jobs to?  Null will use the default queue.
      */
     'tracker-queue' => null,
+
+    /**
+     * Make model overridable
+     */
+    'sent_email_model' => SentEmail::class,
 
     /**
      * Size limit for content length stored in database

--- a/database/migrations/2016_03_01_193027_create_sent_emails_table.php
+++ b/database/migrations/2016_03_01_193027_create_sent_emails_table.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
-use jdavidbakr\MailTracker\Model\SentEmail;
 
 class CreateSentEmailsTable extends Migration
 {
@@ -13,7 +12,8 @@ class CreateSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmail)->getConnectionName())->create('sent_emails', function (Blueprint $table) {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model)->getConnectionName())->create('sent_emails', function (Blueprint $table) {
             $table->increments('id');
             $table->char('hash', 32)->unique();
             $table->text('headers')->nullable();
@@ -32,6 +32,7 @@ class CreateSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->drop('sent_emails');
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->drop('sent_emails');
     }
 }

--- a/database/migrations/2016_11_10_213551_add-message-id-to-sent-emails-table.php
+++ b/database/migrations/2016_11_10_213551_add-message-id-to-sent-emails-table.php
@@ -3,7 +3,6 @@
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
-use jdavidbakr\MailTracker\Model\SentEmail;
 
 class AddMessageIdToSentEmailsTable extends Migration
 {
@@ -14,7 +13,8 @@ class AddMessageIdToSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->string('message_id')->nullable();
             $table->text('meta')->nullable();
         });
@@ -27,10 +27,11 @@ class AddMessageIdToSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('message_id');
         });
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('meta');
         });
     }

--- a/database/migrations/2020_04_15_112152_add_message_id_index_to_sent_emails_table.php
+++ b/database/migrations/2020_04_15_112152_add_message_id_index_to_sent_emails_table.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use Illuminate\Database\Migrations\Migration;
 
 class AddMessageIdIndexToSentEmailsTable extends Migration
@@ -14,7 +13,8 @@ class AddMessageIdIndexToSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->index('message_id');
         });
     }
@@ -26,7 +26,8 @@ class AddMessageIdIndexToSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropIndex('sent_emails_message_id_index');
         });
     }

--- a/database/migrations/2021_02_10_083945_add_sender_email_and_name_to_sent_emails_table.php
+++ b/database/migrations/2021_02_10_083945_add_sender_email_and_name_to_sent_emails_table.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use Illuminate\Database\Migrations\Migration;
 
 class AddSenderEmailAndNameToSentEmailsTable extends Migration
@@ -14,7 +13,8 @@ class AddSenderEmailAndNameToSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->string('recipient_email')->nullable()->after('headers');
             $table->string('recipient_name')->nullable()->after('headers');
             $table->string('sender_email')->nullable()->after('headers');
@@ -29,7 +29,8 @@ class AddSenderEmailAndNameToSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('sender_name');
             $table->dropColumn('sender_email');
             $table->dropColumn('recipient_name');

--- a/database/migrations/2021_02_10_095634_add_first_open_and_first_click_columns.php
+++ b/database/migrations/2021_02_10_095634_add_first_open_and_first_click_columns.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use Illuminate\Database\Migrations\Migration;
 
 class AddFirstOpenAndFirstClickColumns extends Migration
@@ -14,7 +13,8 @@ class AddFirstOpenAndFirstClickColumns extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->datetime('clicked_at')->nullable()->after('updated_at');
             $table->datetime('opened_at')->nullable()->after('updated_at');
         });
@@ -27,7 +27,8 @@ class AddFirstOpenAndFirstClickColumns extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('opened_at');
             $table->dropColumn('clicked_at');
         });

--- a/database/migrations/2021_12_08_235120_add_mailable_id_and_mailable_type_columns.php
+++ b/database/migrations/2021_12_08_235120_add_mailable_id_and_mailable_type_columns.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddMailableIdAndMailableTypeColumns extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+            $table->nullableMorphs('mailable');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $model = config('mail-tracker.sent_email_model');
+        Schema::connection((new $model())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+            $table->dropMorphs('mailable');
+        });
+    }
+}

--- a/src/AdminController.php
+++ b/src/AdminController.php
@@ -8,7 +8,6 @@ use Response;
 use App\Http\Requests;
 use Illuminate\Routing\Controller;
 
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
 
 use Mail;
@@ -43,7 +42,8 @@ class AdminController extends Controller
         session(['mail-tracker-index-page' => request()->page]);
         $search = session('mail-tracker-index-search');
 
-        $query = SentEmail::query();
+        $model = config('mail-tracker.sent_email_model');
+        $query = $model::query();
 
         if ($search) {
             $terms = explode(" ", $search);
@@ -71,7 +71,8 @@ class AdminController extends Controller
      */
     public function getShowEmail($id)
     {
-        $email = SentEmail::where('id', $id)->first();
+        $model = config('mail-tracker.sent_email_model');
+        $email = $model::where('id', $id)->first();
         return \View('emailTrakingViews::show')->with('email', $email);
     }
 
@@ -96,7 +97,8 @@ class AdminController extends Controller
      */
     public function getSMTPDetail($id)
     {
-        $detalle = SentEmail::find($id);
+        $model = config('mail-tracker.sent_email_model');
+        $detalle = $model::find($id);
         if (!$detalle) {
             return back();
         }

--- a/src/Events/PermanentBouncedMessageEvent.php
+++ b/src/Events/PermanentBouncedMessageEvent.php
@@ -16,9 +16,8 @@ class PermanentBouncedMessageEvent implements ShouldQueue
     /**
      * Create a new event instance.
      *
-     * @param  email_address  $email_address
-     * @param  sent_email  $sent_email
-     * @return void
+     * @param string $email_address
+     * @param SentEmail|null $sent_email
      */
     public function __construct($email_address, SentEmail $sent_email = null)
     {

--- a/src/MailTrackerController.php
+++ b/src/MailTrackerController.php
@@ -4,14 +4,9 @@ namespace jdavidbakr\MailTracker;
 
 use App\Http\Requests;
 use Event;
-use Illuminate\Foundation\Support\Providers\RouteServiceProvider;
-
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
-use jdavidbakr\MailTracker\Events\LinkClickedEvent;
 use jdavidbakr\MailTracker\Exceptions\BadUrlLink;
-use jdavidbakr\MailTracker\RecordLinkClickJob;
-use jdavidbakr\MailTracker\RecordTrackingJob;
 use Response;
 
 class MailTrackerController extends Controller
@@ -28,7 +23,8 @@ class MailTrackerController extends Controller
         $response->header('Last-Modified', 'Wed, 11 Jan 2006 12:59:00 GMT');
         $response->header('Pragma', 'no-cache');
 
-        $tracker = Model\SentEmail::where('hash', $hash)
+        $model = config('mail-tracker.sent_email_model');
+        $tracker = $model::where('hash', $hash)
             ->first();
         if ($tracker) {
             RecordTrackingJob::dispatch($tracker, request()->ip())
@@ -63,7 +59,8 @@ class MailTrackerController extends Controller
         if (!$url) {
             $url = config('mail-tracker.redirect-missing-links-to') ?: '/';
         }
-        $tracker = Model\SentEmail::where('hash', $hash)
+        $model = config('mail-tracker.sent_email_model');
+        $tracker = $model::where('hash', $hash)
             ->first();
         if ($tracker) {
             RecordLinkClickJob::dispatch($tracker, $url, request()->ip())

--- a/src/MailTrackerServiceProvider.php
+++ b/src/MailTrackerServiceProvider.php
@@ -49,7 +49,10 @@ class MailTrackerServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        //
+        // merge config for consistency
+        if (!$this->isLumen()) {
+            $this->mergeConfigFrom(__DIR__.'/../config/mail-tracker.php', 'mail-tracker');
+        }
     }
 
     /**

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -2,7 +2,10 @@
 
 namespace jdavidbakr\MailTracker\Model;
 
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * @property string $hash
@@ -14,7 +17,7 @@ use Illuminate\Database\Eloquent\Model;
  * @property int $opens
  * @property int $clicks
  * @property int|null $message_id
- * @property string $meta
+ * @property Collection $meta
  */
 class SentEmail extends Model
 {
@@ -107,6 +110,25 @@ class SentEmail extends Model
             }
         }
         return implode(" | ", $responses);
+    }
+
+    /**
+     * Get content according to log-content-strategy.
+     * @return string|null
+     */
+    public function getContentAttribute(): ?string
+    {
+        if ($content = $this->attributes['content']) {
+            return $content;
+        }
+        if ($contentFilePath = $this->meta->get('content_file_path')) {
+            try {
+                return Storage::disk(config('mail-tracker.tracker-filesystem-folder'))->get($contentFilePath);
+            } catch (FileNotFoundException $e) {
+                return null;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -123,7 +123,7 @@ class SentEmail extends Model
         }
         if ($contentFilePath = $this->meta->get('content_file_path')) {
             try {
-                return Storage::disk(config('mail-tracker.tracker-filesystem-folder'))->get($contentFilePath);
+                return Storage::disk(config('mail-tracker.tracker-filesystem'))->get($contentFilePath);
             } catch (FileNotFoundException $e) {
                 return null;
             }

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -17,7 +17,10 @@ use Illuminate\Support\Facades\Storage;
  * @property int $opens
  * @property int $clicks
  * @property int|null $message_id
+ * @property string|null $mailable_id
+ * @property string|null $mailable_type
  * @property Collection $meta
+ * @property Model|null $mailable
  */
 class SentEmail extends Model
 {
@@ -36,6 +39,8 @@ class SentEmail extends Model
         'meta',
         'opened_at',
         'clicked_at',
+        'mailable_id',
+        'mailable_type',
     ];
 
     protected $casts = [
@@ -158,5 +163,10 @@ class SentEmail extends Model
     public function urlClicks()
     {
         return $this->hasMany(SentEmailUrlClicked::class);
+    }
+
+    public function mailable()
+    {
+        return $this->morphTo('mailable');
     }
 }

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -49,6 +49,16 @@ class SentEmail extends Model
         'clicked_at' => 'datetime',
     ];
 
+    protected static function boot()
+    {
+        parent::boot();
+        static::deleting(function ($email) {
+            if ($email->meta && ($filePath = $email->meta->get('content_file_path'))) {
+                Storage::disk(config('mail-tracker.tracker-filesystem'))->delete($filePath);
+            }
+        });
+    }
+
     public function getConnectionName()
     {
         $connName = config('mail-tracker.connection');

--- a/src/Model/SentEmailUrlClicked.php
+++ b/src/Model/SentEmailUrlClicked.php
@@ -25,6 +25,7 @@ class SentEmailUrlClicked extends Model
 
     public function email()
     {
-        return $this->belongsTo(SentEmail::class, 'sent_email_id');
+        $model = config('mail-tracker.sent_email_model');
+        return $this->belongsTo($model, 'sent_email_id');
     }
 }

--- a/src/RecordBounceJob.php
+++ b/src/RecordBounceJob.php
@@ -10,7 +10,6 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Event;
 use jdavidbakr\MailTracker\Events\PermanentBouncedMessageEvent;
 use jdavidbakr\MailTracker\Events\TransientBouncedMessageEvent;
-use jdavidbakr\MailTracker\Model\SentEmail;
 
 class RecordBounceJob implements ShouldQueue
 {
@@ -33,7 +32,8 @@ class RecordBounceJob implements ShouldQueue
 
     public function handle()
     {
-        $sent_email = SentEmail::where('message_id', $this->message->mail->messageId)->first();
+        $model = config('mail-tracker.sent_email_model');
+        $sent_email = $model::where('message_id', $this->message->mail->messageId)->first();
         if ($sent_email) {
             $meta = collect($sent_email->meta);
             $current_codes = [];

--- a/src/RecordComplaintJob.php
+++ b/src/RecordComplaintJob.php
@@ -8,7 +8,6 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Events\ComplaintMessageEvent;
 
 class RecordComplaintJob implements ShouldQueue
@@ -32,7 +31,8 @@ class RecordComplaintJob implements ShouldQueue
 
     public function handle()
     {
-        $sent_email = SentEmail::where('message_id', $this->message->mail->messageId)->first();
+        $model = config('mail-tracker.sent_email_model');
+        $sent_email = $model::where('message_id', $this->message->mail->messageId)->first();
         if ($sent_email) {
             $meta = collect($sent_email->meta);
             $meta->put('complaint', true);

--- a/src/RecordDeliveryJob.php
+++ b/src/RecordDeliveryJob.php
@@ -8,7 +8,6 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Events\EmailDeliveredEvent;
 
 class RecordDeliveryJob implements ShouldQueue
@@ -32,7 +31,8 @@ class RecordDeliveryJob implements ShouldQueue
 
     public function handle()
     {
-        $sent_email = SentEmail::where('message_id', $this->message->mail->messageId)->first();
+        $model = config('mail-tracker.sent_email_model');
+        $sent_email = $model::where('message_id', $this->message->mail->messageId)->first();
         if ($sent_email) {
             $meta = collect($sent_email->meta);
             $meta->put('smtpResponse', $this->message->delivery->smtpResponse);

--- a/src/RecordLinkClickJob.php
+++ b/src/RecordLinkClickJob.php
@@ -8,10 +8,8 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Events\LinkClickedEvent;
 use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
-use jdavidbakr\MailTracker\Events\EmailDeliveredEvent;
 
 class RecordLinkClickJob implements ShouldQueue
 {

--- a/src/RecordTrackingJob.php
+++ b/src/RecordTrackingJob.php
@@ -8,11 +8,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Events\ViewEmailEvent;
-use jdavidbakr\MailTracker\Events\LinkClickedEvent;
-use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
-use jdavidbakr\MailTracker\Events\EmailDeliveredEvent;
 
 class RecordTrackingJob implements ShouldQueue
 {

--- a/src/SNSController.php
+++ b/src/SNSController.php
@@ -9,14 +9,7 @@ use Illuminate\Http\Request;
 use GuzzleHttp\Client as Guzzle;
 use Aws\Sns\Message as SNSMessage;
 use Illuminate\Routing\Controller;
-use jdavidbakr\MailTracker\Model\SentEmail;
-use jdavidbakr\MailTracker\RecordBounceJob;
-use jdavidbakr\MailTracker\RecordDeliveryJob;
-use jdavidbakr\MailTracker\RecordComplaintJob;
 use Aws\Sns\MessageValidator as SNSMessageValidator;
-use jdavidbakr\MailTracker\Events\EmailDeliveredEvent;
-use jdavidbakr\MailTracker\Events\ComplaintMessageEvent;
-use jdavidbakr\MailTracker\Events\PermanentBouncedMessageEvent;
 
 class SNSController extends Controller
 {

--- a/src/Traits/HasSentEmails.php
+++ b/src/Traits/HasSentEmails.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Traits;
+
+trait HasSentEmails
+{
+    public function sentEmails()
+    {
+        $model = config('mail-tracker.sent_email_model');
+        return $this->morphMany($model, 'mailable');
+    }
+}

--- a/tests/MailTrackerTest.php
+++ b/tests/MailTrackerTest.php
@@ -67,7 +67,6 @@ class MailTrackerTest extends SetUpTest
         $str = Mockery::mock(Str::class);
         app()->instance(Str::class, $str);
         $str->shouldReceive('random')
-            ->once()
             ->andReturn('random-hash');
 
         Event::fake();
@@ -452,7 +451,6 @@ class MailTrackerTest extends SetUpTest
         app()->instance(Str::class, $str);
         $str->shouldReceive('random')
             ->with(32)
-            ->once()
             ->andReturn('random-hash');
         Config::set('mail.driver', 'ses');
         Config::set('mail.default', null);


### PR DESCRIPTION
This is a nice feature update.

1. Content storage strategy:
The new config `log-content-strategy` allows to switch between `database` and `filesystem` as storage strategy for your email content. The problem with database is that the table can get too big and performance decreases.

2. Mailable models:
This allows to attach a model to a sent email by setting a `X-Mailable-Id` and `X-Mailable-Type` customer header. You can then add the `HasSentEmails` trait to selected models to query the related emails easily.

Let me know what you think and if you are interested to include these changes.