### PR TITLE
Update opened_at on click if tracking pixels

### DIFF
--- a/config/mail-tracker.php
+++ b/config/mail-tracker.php
@@ -42,7 +42,7 @@ return [
     ],
 
     /**
-     * Admin Tamplate
+     * Admin Template
      * example
      * 'name' => 'layouts.app' for Default emailTraking use 'emailTrakingViews::layouts.app'
      * 'section' => 'content' for Default emailTraking use 'content'
@@ -74,7 +74,7 @@ return [
     'sns-topic' => null,
 
     /**
-     * Determines whether or not the body of the email is logged in the sent_emails table
+     * Determines whether the body of the email is logged in the sent_emails table
      */
     'log-content' => true,
 


### PR DESCRIPTION
We have times where someone clicks the email but the opened_at hasn't been recognised, normally due to people not loading images by default in their emails. 

I have a custom event listener in my code that triggers this on the Clicked Event, but thought it would be useful in the core code