### PR TITLE
Ability to skip migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ $ php artisan migrate
 Note: If you would like to use a different connection to store your models,
 you should update the mail-tracker.php config entry `connection` before running the migrations.
 
+If you would like to use your own migrations, you can skip this library migrations by calling `MailTracker::ignoreMigrations()`. For example:
+
+```php
+// In AppServiceProvider
+
+public function boot()
+{
+    MailTracker::ignoreMigrations();
+}
+```
+
 ## Usage
 
 Once installed, all outgoing mail will be logged to the database. The following config options are available in config/mail-tracker.php:

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -10,6 +10,9 @@ use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
 
 class MailTracker implements \Swift_Events_SendListener
 {
+    // Set this to "false" to skip this library migrations
+    public static $runsMigrations = true;
+
     protected $hash;
 
     /**

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -16,6 +16,18 @@ class MailTracker implements \Swift_Events_SendListener
     protected $hash;
 
     /**
+     * Configure this library to not register its migrations.
+     *
+     * @return static
+     */
+    public static function ignoreMigrations()
+    {
+        static::$runsMigrations = false;
+
+        return new static;
+    }
+
+    /**
      * Inject the tracking code into the message
      */
     public function beforeSendPerformed(\Swift_Events_SendEvent $event)

--- a/src/MailTrackerServiceProvider.php
+++ b/src/MailTrackerServiceProvider.php
@@ -27,9 +27,12 @@ class MailTrackerServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        if (MailTracker::$runsMigrations && $this->app->runningInConsole()) {
+            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        }
+
         // Publish pieces
         $this->publishConfig();
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         $this->publishViews();
 
         // Register console commands


### PR DESCRIPTION
Hi there,

Thanks for the awesome library. I have been using that on multiple projects and loving it.
However, I always have to do 1 extra thing when installing this package, which is to change the migration structure to suit my needs.

For example:
- change `id` to unsigned big int (so I can consistently declare foreign constants easily)
- change the `content` to longtext

So I thought it would be good that we can ignore the default migrations and use our own.

Usage:

```php
// In AppServiceProvider

public function boot()
{
    MailTracker::ignoreMigrations();
}
```