### PR TITLE
UUIDs functionality

### DIFF
--- a/config/mail-tracker.php
+++ b/config/mail-tracker.php
@@ -87,4 +87,10 @@ return [
      * Size limit for content length stored in database
      */
     'content-max-size' => 65535,
+
+    /**
+     * Determines if you need your models to use UUIDs as primary keys.
+     *  Column name remains unchanged - `id`.
+     */
+    'use_uuids' => false
 ];

--- a/database/migrations/2016_03_01_193027_create_sent_emails_table.php
+++ b/database/migrations/2016_03_01_193027_create_sent_emails_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 use jdavidbakr\MailTracker\Model\SentEmail;
 
 class CreateSentEmailsTable extends Migration
@@ -14,7 +15,11 @@ class CreateSentEmailsTable extends Migration
     public function up()
     {
         Schema::connection((new SentEmail)->getConnectionName())->create('sent_emails', function (Blueprint $table) {
-            $table->increments('id');
+            if (config('mail-tracker.use_uuids')) {
+                $table->uuid('id')->primary();
+            } else {
+                $table->increments('id');
+            }
             $table->char('hash', 32)->unique();
             $table->text('headers')->nullable();
             $table->string('subject')->nullable();
@@ -23,6 +28,9 @@ class CreateSentEmailsTable extends Migration
             $table->integer('clicks')->nullable();
             $table->timestamps();
         });
+        if (config('mail-tracker.use_uuids')) {
+            DB::statement('ALTER TABLE sent_emails ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        }
     }
 
     /**

--- a/database/migrations/2016_09_07_193027_create_sent_emails_Url_Clicked_table.php
+++ b/database/migrations/2016_09_07_193027_create_sent_emails_Url_Clicked_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
 use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
 
 class CreateSentEmailsUrlClickedTable extends Migration
@@ -14,7 +15,11 @@ class CreateSentEmailsUrlClickedTable extends Migration
     public function up()
     {
         Schema::connection((new SentEmailUrlClicked())->getConnectionName())->create('sent_emails_url_clicked', function (Blueprint $table) {
-            $table->increments('id');
+            if (config('mail-tracker.use_uuids')) {
+                $table->uuid('id')->primary();
+            } else {
+                $table->increments('id');
+            }
             $table->integer('sent_email_id')->unsigned();
             $table->foreign('sent_email_id')->references('id')->on('sent_emails')->onDelete('cascade');
             $table->text('url')->nullable();
@@ -22,6 +27,9 @@ class CreateSentEmailsUrlClickedTable extends Migration
             $table->integer('clicks')->default('1');
             $table->timestamps();
         });
+        if (config('mail-tracker.use_uuids')) {
+            DB::statement('ALTER TABLE sent_emails_url_clicked ALTER COLUMN id SET DEFAULT uuid_generate_v4();');
+        }
     }
 
     /**

--- a/database/migrations/2016_09_07_193027_create_sent_emails_Url_Clicked_table.php
+++ b/database/migrations/2016_09_07_193027_create_sent_emails_Url_Clicked_table.php
@@ -17,10 +17,11 @@ class CreateSentEmailsUrlClickedTable extends Migration
         Schema::connection((new SentEmailUrlClicked())->getConnectionName())->create('sent_emails_url_clicked', function (Blueprint $table) {
             if (config('mail-tracker.use_uuids')) {
                 $table->uuid('id')->primary();
+                $table->uuid('sent_email_id')->unsigned();
             } else {
                 $table->increments('id');
+                $table->integer('sent_email_id')->unsigned();
             }
-            $table->integer('sent_email_id')->unsigned();
             $table->foreign('sent_email_id')->references('id')->on('sent_emails')->onDelete('cascade');
             $table->text('url')->nullable();
             $table->char('hash', 32);

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -41,6 +41,12 @@ class SentEmail extends Model
         'clicked_at' => 'datetime',
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+        $this->keyType = (config('mail-tracker.use_uuids')) ? 'string' : 'int';
+    }
+
     public function getConnectionName()
     {
         $connName = config('mail-tracker.connection');

--- a/src/Model/SentEmailUrlClicked.php
+++ b/src/Model/SentEmailUrlClicked.php
@@ -17,6 +17,12 @@ class SentEmailUrlClicked extends Model
         'clicks',
     ];
 
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+        $this->keyType = (config('mail-tracker.use_uuids')) ? 'string' : 'int';
+    }
+
     public function getConnectionName()
     {
         $connName = config('mail-tracker.connection');


### PR DESCRIPTION
If you need to use UUIDs in your project, you can specify in config `use_uuids=true` and all tables, generated by this package, will use id (uuid) as primary keys.