### PR TITLE
Ability to access the clicked URL in LinkClickedEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ You may want to do additional processing on these events, so an event is fired i
 -   jdavidbakr\MailTracker\Events\LinkClickedEvent
     - Public attribute `sent_email` contains the `SentEmail` model
     - Public attribute `ip_address` contains the IP address that was used to trigger the event
+    - Public attribute `link_url` contains the clicked URL
 
 If you are using the Amazon SNS notification system, these events are fired so you can do additional processing.
 

--- a/src/Events/LinkClickedEvent.php
+++ b/src/Events/LinkClickedEvent.php
@@ -12,16 +12,19 @@ class LinkClickedEvent implements ShouldQueue
 
     public $sent_email;
     public $ip_address;
+    public $link_url;
 
     /**
      * Create a new event instance.
      *
-     * @param  sent_email  $sent_email
-     * @return void
+     * @param SentEmail $sent_email
+     * @param string $ip_address
+     * @param string $link_url
      */
-    public function __construct(SentEmail $sent_email, $ip_address)
+    public function __construct(SentEmail $sent_email, $ip_address, $link_url)
     {
         $this->sent_email = $sent_email;
         $this->ip_address = $ip_address;
+        $this->link_url = $link_url;
     }
 }

--- a/src/RecordLinkClickJob.php
+++ b/src/RecordLinkClickJob.php
@@ -51,6 +51,10 @@ class RecordLinkClickJob implements ShouldQueue
                 'hash' => $this->sentEmail->hash,
             ]);
         }
-        Event::dispatch(new LinkClickedEvent($this->sentEmail, $this->ipAddress));
+        Event::dispatch(new LinkClickedEvent(
+            $this->sentEmail,
+            $this->ipAddress,
+            $this->url,
+        ));
     }
 }

--- a/tests/RecordLinkClickJobTest.php
+++ b/tests/RecordLinkClickJobTest.php
@@ -26,12 +26,13 @@ class RecordLinkClickJobTest extends SetUpTest
         $clicks++;
         $redirect = 'http://'.Str::random(15).'.com/'.Str::random(10).'/'.Str::random(10).'/'.rand(0, 100).'/'.rand(0, 100).'?page='.rand(0, 100).'&x='.Str::random(32);
         $job = new RecordLinkClickJob($track, $redirect, '127.0.0.1');
-        
+
         $job->handle();
 
-        Event::assertDispatched(LinkClickedEvent::class, function ($e) use ($track) {
-            return $track->id == $e->sent_email->id &&
-                $e->ip_address == '127.0.0.1';
+        Event::assertDispatched(LinkClickedEvent::class, function ($e) use ($track, $redirect) {
+            return $track->id === $e->sent_email->id &&
+                $e->ip_address === '127.0.0.1' &&
+                $e->link_url === $redirect;
         });
         $this->assertDatabaseHas('sent_emails_url_clicked', [
                 'url' => $redirect,


### PR DESCRIPTION
This PR allows us to access the clicked URL via `LinkClickedEvent`.

This is useful for people who want to perform extra tasks based on the clicked link.