### PR TITLE
Fixes mime part duplication.

### DIFF
--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -212,22 +212,6 @@ class MailTracker
                     $messageBody = $message->getBody() ?: [];
                     $newParts = [];
                     foreach($messageBody->getParts() as $part) {
-                        if (method_exists($part, 'getParts')) {
-                            foreach ($part->getParts() as $p) {
-                                if($p->getMediaSubtype() == 'html') {
-                                    $original_html = $p->getBody();
-                                    $newParts[] = new TextPart(
-                                        $this->addTrackers($original_html, $hash),
-                                        $message->getHtmlCharset(),
-                                        $p->getMediaSubtype(),
-                                        null
-                                    );
-
-                                    break;
-                                }
-                            }
-                        }
-
                         if($part->getMediaSubtype() == 'html') {
                             $original_html = $part->getBody();
                             $newParts[] = new TextPart(
@@ -236,6 +220,22 @@ class MailTracker
                                 $part->getMediaSubtype(),
                                 null
                             );
+                        } else if ($part->getMediaSubtype() == 'alternative') {
+                            if (method_exists($part, 'getParts')) {
+                                foreach ($part->getParts() as $p) {
+                                    if($p->getMediaSubtype() == 'html') {
+                                        $original_html = $p->getBody();
+                                        $newParts[] = new TextPart(
+                                            $this->addTrackers($original_html, $hash),
+                                            $message->getHtmlCharset(),
+                                            $p->getMediaSubtype(),
+                                            null
+                                        );
+
+                                        break;
+                                    }
+                                }
+                            }
                         } else {
                             $newParts[] = $part;
                         }


### PR DESCRIPTION
Implemented a fix for #197 by specifically checking for the mime part of type alternative, and then inject a pixel only when that part is of type html. This solves the part being injected twice, resulting in duplication the mail's content.