### PR TITLE
Fix type of $message paramter in createTrackers method

### DIFF
--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 use jdavidbakr\MailTracker\Events\EmailSentEvent;
 use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
+use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
 use Symfony\Component\Mime\Part\Multipart\MixedPart;
 use Symfony\Component\Mime\Part\Multipart\RelatedPart;
@@ -177,10 +178,10 @@ class MailTracker
     /**
      * Create the trackers
      *
-     * @param  Swift_Mime_Message $message
+     * @param  Email $message
      * @return void
      */
-    protected function createTrackers($message)
+    protected function createTrackers(Email $message)
     {
         foreach ($message->getTo() as $toAddress) {
             $to_email = $toAddress->getAddress();

--- a/src/MailTrackerServiceProvider.php
+++ b/src/MailTrackerServiceProvider.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
-use Mail;
 
 class MailTrackerServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
PHPDoc and used old Swift_Mime_Message

Changed it to use new Email class in `createTrackers()` methods

Also removed unused namespace `Email`