### PR TITLE
Fix old namespace

### DIFF
--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 use jdavidbakr\MailTracker\Events\EmailSentEvent;
 use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
+use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Part\Multipart\AlternativePart;
 use Symfony\Component\Mime\Part\Multipart\MixedPart;
 use Symfony\Component\Mime\Part\Multipart\RelatedPart;
@@ -177,10 +178,10 @@ class MailTracker
     /**
      * Create the trackers
      *
-     * @param  Swift_Mime_Message $message
+     * @param  Email $message
      * @return void
      */
-    protected function createTrackers($message)
+    protected function createTrackers(Email $message)
     {
         foreach ($message->getTo() as $toAddress) {
             $to_email = $toAddress->getAddress();

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -181,7 +181,7 @@ class MailTracker
      * @param  Email $message
      * @return void
      */
-    protected function createTrackers(Email $message)
+    protected function createTrackers($message)
     {
         foreach ($message->getTo() as $toAddress) {
             $to_email = $toAddress->getAddress();

--- a/src/MailTrackerServiceProvider.php
+++ b/src/MailTrackerServiceProvider.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
-use Mail;
 
 class MailTrackerServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
Last, MR broke tests because the method gets Mockery objects. So I removed the type from the signature again and just use it in the PHPDoc.