### PR TITLE
Make models overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,28 @@ You can specify the disk with `tracker-filesystem` and the folder it should stor
 In some cases you want to override the built-in models. You can do so easily for example in you `AppServiceProvider` with
 
 ```php
-\jdavidbakr\MailTracker\MailTracker::useSentEmailModel(YourOwnSentEmailModel::class);
-\jdavidbakr\MailTracker\MailTracker::useSentEmailUrlClickedModel(YourOwnSentEmailUrlClickedModel::class);
+MailTracker::useSentEmailModel(YourOwnSentEmailModel::class);
+MailTracker::useSentEmailUrlClickedModel(YourOwnSentEmailUrlClickedModel::class);
+```
+
+Your model should implement to `SentEmailModel` or `SentEmailUrlClickedModel` interface. This package provides traits to easily implement your own models but not have to reimplement or copy existing code.
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use jdavidbakr\MailTracker\Concerns\IsSentEmailModel;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
+
+class OwnEmailSentModel extends Model implements SentEmailModel {
+    use IsSentEmailModel;
+
+    protected static $unguarded = true;
+
+    protected $casts = [
+        'meta' => 'collection',
+        'opened_at' => 'datetime',
+        'clicked_at' => 'datetime',
+    ];
+}
 ```
 
 ## Note on dev testing

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ If a lot of emails are sent, this can consume a lot of memory and slow down the 
 To use the filesystem you need to change the `log-content-strategy` from `database` to `filesystem`. 
 You can specify the disk with `tracker-filesystem` and the folder it should store the file in with `tracker-filesystem-folder`.
 
+### Overriding models
+
+In some cases you want to override the built-in models. You can do so easily for example in you `AppServiceProvider` with
+
+```php
+\jdavidbakr\MailTracker\MailTracker::useSentEmailModel(YourOwnSentEmailModel::class);
+\jdavidbakr\MailTracker\MailTracker::useSentEmailUrlClickedModel(YourOwnSentEmailUrlClickedModel::class);
+```
+
 ## Note on dev testing
 
 Several people have reported the tracking pixel not working while they were testing. What is happening with the tracking pixel is that the email client is connecting to your website to log the view. In order for this to happen, images have to be visible in the client, and the client has to be able to connect to your server.

--- a/database/migrations/2016_03_01_193027_create_sent_emails_table.php
+++ b/database/migrations/2016_03_01_193027_create_sent_emails_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use Illuminate\Database\Schema\Blueprint;
+use jdavidbakr\MailTracker\MailTracker;
 
 class CreateSentEmailsTable extends Migration
 {
@@ -13,7 +13,7 @@ class CreateSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmail)->getConnectionName())->create('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->create('sent_emails', function (Blueprint $table) {
             $table->increments('id');
             $table->char('hash', 32)->unique();
             $table->text('headers')->nullable();
@@ -32,6 +32,6 @@ class CreateSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->drop('sent_emails');
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->drop('sent_emails');
     }
 }

--- a/database/migrations/2016_03_01_193027_create_sent_emails_table.php
+++ b/database/migrations/2016_03_01_193027_create_sent_emails_table.php
@@ -13,7 +13,7 @@ class CreateSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->create('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->create('sent_emails', function (Blueprint $table) {
             $table->increments('id');
             $table->char('hash', 32)->unique();
             $table->text('headers')->nullable();
@@ -32,6 +32,6 @@ class CreateSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->drop('sent_emails');
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->drop('sent_emails');
     }
 }

--- a/database/migrations/2016_09_07_193027_create_sent_emails_Url_Clicked_table.php
+++ b/database/migrations/2016_09_07_193027_create_sent_emails_Url_Clicked_table.php
@@ -14,7 +14,7 @@ class CreateSentEmailsUrlClickedTable extends Migration
      */
     public function up()
     {
-        Schema::connection(MailTracker::newSentEmailUrlClickedModel()->getConnectionName())->create('sent_emails_url_clicked', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailUrlClickedModel()->getConnectionName())->create('sent_emails_url_clicked', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('sent_email_id')->unsigned();
             $table->foreign('sent_email_id')->references('id')->on('sent_emails')->onDelete('cascade');
@@ -32,6 +32,6 @@ class CreateSentEmailsUrlClickedTable extends Migration
      */
     public function down()
     {
-        Schema::connection(MailTracker::newSentEmailUrlClickedModel()->getConnectionName())->drop('sent_emails_url_clicked');
+        Schema::connection(MailTracker::sentEmailUrlClickedModel()->getConnectionName())->drop('sent_emails_url_clicked');
     }
 }

--- a/database/migrations/2016_09_07_193027_create_sent_emails_Url_Clicked_table.php
+++ b/database/migrations/2016_09_07_193027_create_sent_emails_Url_Clicked_table.php
@@ -1,8 +1,9 @@
 <?php
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
-use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
+use jdavidbakr\MailTracker\MailTracker;
 
 class CreateSentEmailsUrlClickedTable extends Migration
 {
@@ -13,7 +14,7 @@ class CreateSentEmailsUrlClickedTable extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmailUrlClicked())->getConnectionName())->create('sent_emails_url_clicked', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailUrlClickedModel()->getConnectionName())->create('sent_emails_url_clicked', function (Blueprint $table) {
             $table->increments('id');
             $table->integer('sent_email_id')->unsigned();
             $table->foreign('sent_email_id')->references('id')->on('sent_emails')->onDelete('cascade');
@@ -31,6 +32,6 @@ class CreateSentEmailsUrlClickedTable extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmailUrlClicked())->getConnectionName())->drop('sent_emails_url_clicked');
+        Schema::connection(MailTracker::newSentEmailUrlClickedModel()->getConnectionName())->drop('sent_emails_url_clicked');
     }
 }

--- a/database/migrations/2016_11_10_213551_add-message-id-to-sent-emails-table.php
+++ b/database/migrations/2016_11_10_213551_add-message-id-to-sent-emails-table.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use jdavidbakr\MailTracker\MailTracker;
 
 class AddMessageIdToSentEmailsTable extends Migration
 {
@@ -14,7 +14,7 @@ class AddMessageIdToSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->string('message_id')->nullable();
             $table->text('meta')->nullable();
         });
@@ -27,10 +27,10 @@ class AddMessageIdToSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('message_id');
         });
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('meta');
         });
     }

--- a/database/migrations/2016_11_10_213551_add-message-id-to-sent-emails-table.php
+++ b/database/migrations/2016_11_10_213551_add-message-id-to-sent-emails-table.php
@@ -14,7 +14,7 @@ class AddMessageIdToSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->string('message_id')->nullable();
             $table->text('meta')->nullable();
         });
@@ -27,10 +27,10 @@ class AddMessageIdToSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('message_id');
         });
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('meta');
         });
     }

--- a/database/migrations/2020_04_15_112152_add_message_id_index_to_sent_emails_table.php
+++ b/database/migrations/2020_04_15_112152_add_message_id_index_to_sent_emails_table.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use jdavidbakr\MailTracker\MailTracker;
 
 class AddMessageIdIndexToSentEmailsTable extends Migration
 {
@@ -14,7 +14,7 @@ class AddMessageIdIndexToSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->index('message_id');
         });
     }
@@ -26,7 +26,7 @@ class AddMessageIdIndexToSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropIndex('sent_emails_message_id_index');
         });
     }

--- a/database/migrations/2020_04_15_112152_add_message_id_index_to_sent_emails_table.php
+++ b/database/migrations/2020_04_15_112152_add_message_id_index_to_sent_emails_table.php
@@ -14,7 +14,7 @@ class AddMessageIdIndexToSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->index('message_id');
         });
     }
@@ -26,7 +26,7 @@ class AddMessageIdIndexToSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropIndex('sent_emails_message_id_index');
         });
     }

--- a/database/migrations/2021_02_10_083945_add_sender_email_and_name_to_sent_emails_table.php
+++ b/database/migrations/2021_02_10_083945_add_sender_email_and_name_to_sent_emails_table.php
@@ -14,7 +14,7 @@ class AddSenderEmailAndNameToSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->string('recipient_email')->nullable()->after('headers');
             $table->string('recipient_name')->nullable()->after('headers');
             $table->string('sender_email')->nullable()->after('headers');
@@ -29,7 +29,7 @@ class AddSenderEmailAndNameToSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('sender_name');
             $table->dropColumn('sender_email');
             $table->dropColumn('recipient_name');

--- a/database/migrations/2021_02_10_083945_add_sender_email_and_name_to_sent_emails_table.php
+++ b/database/migrations/2021_02_10_083945_add_sender_email_and_name_to_sent_emails_table.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use jdavidbakr\MailTracker\MailTracker;
 
 class AddSenderEmailAndNameToSentEmailsTable extends Migration
 {
@@ -14,7 +14,7 @@ class AddSenderEmailAndNameToSentEmailsTable extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->string('recipient_email')->nullable()->after('headers');
             $table->string('recipient_name')->nullable()->after('headers');
             $table->string('sender_email')->nullable()->after('headers');
@@ -29,7 +29,7 @@ class AddSenderEmailAndNameToSentEmailsTable extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('sender_name');
             $table->dropColumn('sender_email');
             $table->dropColumn('recipient_name');

--- a/database/migrations/2021_02_10_095634_add_first_open_and_first_click_columns.php
+++ b/database/migrations/2021_02_10_095634_add_first_open_and_first_click_columns.php
@@ -1,9 +1,9 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use jdavidbakr\MailTracker\MailTracker;
 
 class AddFirstOpenAndFirstClickColumns extends Migration
 {
@@ -14,7 +14,7 @@ class AddFirstOpenAndFirstClickColumns extends Migration
      */
     public function up()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->datetime('clicked_at')->nullable()->after('updated_at');
             $table->datetime('opened_at')->nullable()->after('updated_at');
         });
@@ -27,7 +27,7 @@ class AddFirstOpenAndFirstClickColumns extends Migration
      */
     public function down()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('opened_at');
             $table->dropColumn('clicked_at');
         });

--- a/database/migrations/2021_02_10_095634_add_first_open_and_first_click_columns.php
+++ b/database/migrations/2021_02_10_095634_add_first_open_and_first_click_columns.php
@@ -14,7 +14,7 @@ class AddFirstOpenAndFirstClickColumns extends Migration
      */
     public function up()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->datetime('clicked_at')->nullable()->after('updated_at');
             $table->datetime('opened_at')->nullable()->after('updated_at');
         });
@@ -27,7 +27,7 @@ class AddFirstOpenAndFirstClickColumns extends Migration
      */
     public function down()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->dropColumn('opened_at');
             $table->dropColumn('clicked_at');
         });

--- a/src/AdminController.php
+++ b/src/AdminController.php
@@ -3,15 +3,7 @@
 namespace jdavidbakr\MailTracker;
 
 use Illuminate\Http\Request;
-use Response;
-
-use App\Http\Requests;
 use Illuminate\Routing\Controller;
-
-use jdavidbakr\MailTracker\Model\SentEmail;
-use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
-
-use Mail;
 
 class AdminController extends Controller
 {
@@ -43,7 +35,7 @@ class AdminController extends Controller
         session(['mail-tracker-index-page' => request()->page]);
         $search = session('mail-tracker-index-search');
 
-        $query = SentEmail::query();
+        $query = MailTracker::newSentEmailModel()->query();
 
         if ($search) {
             $terms = explode(" ", $search);
@@ -71,7 +63,7 @@ class AdminController extends Controller
      */
     public function getShowEmail($id)
     {
-        $email = SentEmail::where('id', $id)->first();
+        $email = MailTracker::newSentEmailModel()->newQuery()->where('id', $id)->first();
         return \View('emailTrakingViews::show')->with('email', $email);
     }
 
@@ -82,13 +74,13 @@ class AdminController extends Controller
      */
     public function getUrlDetail($id)
     {
-        $detalle = SentEmailUrlClicked::where('sent_email_id', $id)
+        $details = MailTracker::newSentEmailUrlClickedModel()->newQuery()->where('sent_email_id', $id)
             ->with('email')
             ->get();
-        if (!$detalle) {
+        if (!$details) {
             return back();
         }
-        return \View('emailTrakingViews::url_detail')->with('details', $detalle);
+        return \View('emailTrakingViews::url_detail')->with('details', $details);
     }
 
     /**
@@ -98,10 +90,10 @@ class AdminController extends Controller
      */
     public function getSMTPDetail($id)
     {
-        $detalle = SentEmail::find($id);
-        if (!$detalle) {
+        $details = MailTracker::newSentEmailModel()->newQuery()->find($id);
+        if (!$details) {
             return back();
         }
-        return \View('emailTrakingViews::smtp_detail')->with('details', $detalle);
+        return \View('emailTrakingViews::smtp_detail')->with('details', $details);
     }
 }

--- a/src/AdminController.php
+++ b/src/AdminController.php
@@ -35,7 +35,7 @@ class AdminController extends Controller
         session(['mail-tracker-index-page' => request()->page]);
         $search = session('mail-tracker-index-search');
 
-        $query = MailTracker::newSentEmailModel()->query();
+        $query = MailTracker::sentEmailModel()->query();
 
         if ($search) {
             $terms = explode(" ", $search);
@@ -63,7 +63,7 @@ class AdminController extends Controller
      */
     public function getShowEmail($id)
     {
-        $email = MailTracker::newSentEmailModel()->newQuery()->where('id', $id)->first();
+        $email = MailTracker::sentEmailModel()->newQuery()->where('id', $id)->first();
         return \View('emailTrakingViews::show')->with('email', $email);
     }
 
@@ -74,7 +74,7 @@ class AdminController extends Controller
      */
     public function getUrlDetail($id)
     {
-        $details = MailTracker::newSentEmailUrlClickedModel()->newQuery()->where('sent_email_id', $id)
+        $details = MailTracker::sentEmailUrlClickedModel()->newQuery()->where('sent_email_id', $id)
             ->with('email')
             ->get();
         if (!$details) {
@@ -90,7 +90,7 @@ class AdminController extends Controller
      */
     public function getSMTPDetail($id)
     {
-        $details = MailTracker::newSentEmailModel()->newQuery()->find($id);
+        $details = MailTracker::sentEmailModel()->newQuery()->find($id);
         if (!$details) {
             return back();
         }

--- a/src/Concerns/IsSentEmailModel.php
+++ b/src/Concerns/IsSentEmailModel.php
@@ -3,16 +3,18 @@
 namespace jdavidbakr\MailTracker\Concerns;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 use jdavidbakr\MailTracker\MailTracker;
 
 trait IsSentEmailModel
 {
-    public function booIsSentEmailModel()
+    public static function bootIsSentEmailModel()
     {
-        static::deleting(function (self $email) {
+        static::deleting(function (Model|SentEmailModel $email) {
             if ($filePath = $email->meta?->get('content_file_path')) {
                 Storage::disk(config('mail-tracker.tracker-filesystem'))->delete($filePath);
             }

--- a/src/Concerns/IsSentEmailModel.php
+++ b/src/Concerns/IsSentEmailModel.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Concerns;
+
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use jdavidbakr\MailTracker\MailTracker;
+
+trait IsSentEmailModel
+{
+    public function booIsSentEmailModel()
+    {
+        static::deleting(function (self $email) {
+            if ($filePath = $email->meta?->get('content_file_path')) {
+                Storage::disk(config('mail-tracker.tracker-filesystem'))->delete($filePath);
+            }
+        });
+    }
+
+    public function getConnectionName()
+    {
+        $connName = config('mail-tracker.connection');
+        return $connName ?: config('database.default');
+    }
+
+    /**
+     * Returns a bootstrap class about the success/failure of the message
+     * @return [type] [description]
+     */
+    public function getReportClassAttribute()
+    {
+        if (!empty($this->meta) && $this->meta->has('success')) {
+            if ($this->meta->get('success')) {
+                return 'success';
+            } else {
+                return 'danger';
+            }
+        } else {
+            return '';
+        }
+    }
+
+    public function getSenderAttribute()
+    {
+        return $this->sender_name.' <'.$this->sender_email.'>';
+    }
+
+    public function getRecipientAttribute()
+    {
+        return $this->recipient_name.' <'.$this->recipient_email.'>';
+    }
+
+    /**
+     * Returns the smtp detail for this message ()
+     * @return [type] [description]
+     */
+    public function getSmtpInfoAttribute()
+    {
+        if (empty($this->meta)) {
+            return '';
+        }
+        $meta = $this->meta;
+        $responses = [];
+        if ($meta->has('smtpResponse')) {
+            $response = $meta->get('smtpResponse');
+            $delivered_at = $meta->get('delivered_at');
+            $responses[] = $response.' - Delivered '.$delivered_at;
+        }
+        if ($meta->has('failures')) {
+            foreach ($meta->get('failures') as $failure) {
+                if (!empty($failure['status'])) {
+                    $responses[] = $failure['status'].' ('.$failure['action'].'): '.$failure['diagnosticCode'].' ('.$failure['emailAddress'].')';
+                } else {
+                    $responses[] = 'Generic Failure ('.$failure['emailAddress'].')';
+                }
+            }
+        } elseif ($meta->has('complaint')) {
+            $complaint_time = $meta->get('complaint_time');
+            if ($meta->get('complaint_type')) {
+                $responses[] = 'Complaint: '.$meta->get('complaint_type').' at '.$complaint_time;
+            } else {
+                $responses[] = 'Complaint at '.$complaint_time->format("n/d/y g:i a");
+            }
+        }
+        return implode(" | ", $responses);
+    }
+
+    /**
+     * Get content according to log-content-strategy.
+     * @return string|null
+     */
+    public function getContentAttribute(): ?string
+    {
+        if ($content = $this->attributes['content']) {
+            return $content;
+        }
+        if ($contentFilePath = $this->meta->get('content_file_path')) {
+            try {
+                return Storage::disk(config('mail-tracker.tracker-filesystem'))->get($contentFilePath);
+            } catch (FileNotFoundException $e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns a collection of all headers requested from our stored header info
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getAllHeaders()
+    {
+        return collect(preg_split("/(\r\n)(?!\s)/", $this->headers))
+            ->filter(function ($header) {
+                return preg_match("/:/", $header);
+            })
+            ->transform(function ($header) {
+                $header = Str::replace("\r\n", '', $header);
+                list($key, $value) = explode(":", $header, 2);
+                return collect([
+                    'key' => trim($key),
+                    'value' => trim($value)
+                ]);
+            })->filter(function ($header) {
+                return $header->get('key');
+            })->keyBy('key')
+            ->transform(function ($header) {
+                return $header->get('value');
+            });
+    }
+
+    /**
+     * Returns the header requested from our stored header info
+     */
+    public function getHeader($key)
+    {
+        return $this->getAllHeaders()->get($key);
+    }
+
+    public function urlClicks()
+    {
+        return $this->hasMany(MailTracker::$sentEmailUrlClickedModel);
+    }
+
+    public function fillContent(string $originalHtml, string $hash)
+    {
+        $logContent = config('mail-tracker.log-content', true);
+
+        if(!$logContent) {
+            return;
+        }
+
+        $logContentStrategy = config('mail-tracker.log-content-strategy', 'database');
+
+        if(!in_array($logContentStrategy, ['database', 'filesystem'])) {
+            return;
+        }
+
+        $databaseContent = null;
+
+        // handling filesystem strategy
+        if ($logContentStrategy === 'filesystem') {
+            // store body in html file
+            $basePath = config('mail-tracker.tracker-filesystem-folder', 'mail-tracker');
+            $fileSystem = config('mail-tracker.tracker-filesystem');
+            $contentFilePath = "{$basePath}/{$hash}.html";
+
+            try {
+                Storage::disk($fileSystem)->put($contentFilePath, $originalHtml);
+            } catch (\Exception $e) {
+                Log::warning($e->getMessage());
+                // fail silently
+            }
+
+            $meta = collect($this->meta);
+            $meta->put('content_file_path', $contentFilePath);
+            $this->meta = $meta;
+        }
+
+        // handling database strategy
+        if ($logContentStrategy === 'database') {
+            $databaseContent = Str::length($originalHtml) > config('mail-tracker.content-max-size', 65535)
+                ? Str::substr($originalHtml, 0, config('mail-tracker.content-max-size', 65535)) . '...'
+                : $originalHtml;
+        }
+
+        $this->content = $databaseContent;
+    }
+}

--- a/src/Concerns/IsSentEmailUrlClickedModel.php
+++ b/src/Concerns/IsSentEmailUrlClickedModel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Concerns;
+
+use jdavidbakr\MailTracker\MailTracker;
+
+trait IsSentEmailUrlClickedModel
+{
+
+    public function getConnectionName()
+    {
+        $connName = config('mail-tracker.connection');
+        return $connName ?: config('database.default');
+    }
+
+    public function email()
+    {
+        return $this->belongsTo(MailTracker::$sentEmailModel, 'sent_email_id');
+    }
+}

--- a/src/Console/MigrateRecipients.php
+++ b/src/Console/MigrateRecipients.php
@@ -29,9 +29,9 @@ class MigrateRecipients extends Command
      */
     public function handle()
     {
-        $bar = optional($this->output)->createProgressBar(MailTracker::newSentEmailModel()->newQuery()->count());
+        $bar = optional($this->output)->createProgressBar(MailTracker::sentEmailModel()->newQuery()->count());
         optional($bar)->start();
-        DB::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails')->orderBy('id')->chunk(100, function ($emails) use ($bar) {
+        DB::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails')->orderBy('id')->chunk(100, function ($emails) use ($bar) {
             $emails->each(function ($email) use ($bar) {
                 if ($email->recipient_email == null) {
                     $this->migrateEmail($email);
@@ -54,7 +54,7 @@ class MigrateRecipients extends Command
             $recipient_name = $matches[1];
             $recipient_email = $matches[2];
         }
-        MailTracker::newSentEmailModel()->newQuery()->where('id', $email->id)
+        MailTracker::sentEmailModel()->newQuery()->where('id', $email->id)
             ->update([
                 'sender_name' => trim($sender_name),
                 'sender_email' => trim($sender_email),

--- a/src/Console/MigrateRecipients.php
+++ b/src/Console/MigrateRecipients.php
@@ -4,7 +4,7 @@ namespace jdavidbakr\MailTracker\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use jdavidbakr\MailTracker\MailTracker;
 
 class MigrateRecipients extends Command
 {
@@ -29,9 +29,9 @@ class MigrateRecipients extends Command
      */
     public function handle()
     {
-        $bar = optional($this->output)->createProgressBar(SentEmail::count());
+        $bar = optional($this->output)->createProgressBar(MailTracker::newSentEmailModel()->newQuery()->count());
         optional($bar)->start();
-        DB::connection((new SentEmail)->getConnectionName())->table('sent_emails')->orderBy('id')->chunk(100, function ($emails) use ($bar) {
+        DB::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails')->orderBy('id')->chunk(100, function ($emails) use ($bar) {
             $emails->each(function ($email) use ($bar) {
                 if ($email->recipient_email == null) {
                     $this->migrateEmail($email);
@@ -54,7 +54,7 @@ class MigrateRecipients extends Command
             $recipient_name = $matches[1];
             $recipient_email = $matches[2];
         }
-        SentEmail::where('id', $email->id)
+        MailTracker::newSentEmailModel()->newQuery()->where('id', $email->id)
             ->update([
                 'sender_name' => trim($sender_name),
                 'sender_email' => trim($sender_email),

--- a/src/Contracts/SentEmailModel.php
+++ b/src/Contracts/SentEmailModel.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Contracts;
+
+interface SentEmailModel
+{
+    public function getConnectionName();
+    public function getAllHeaders();
+    public function getHeader(string $key);
+    public function fillContent(string $originalHtml, string $hash);
+    public function urlClicks();
+}

--- a/src/Contracts/SentEmailUrlClickedModel.php
+++ b/src/Contracts/SentEmailUrlClickedModel.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Contracts;
+
+interface SentEmailUrlClickedModel
+{
+    public function getConnectionName();
+    public function email();
+}

--- a/src/Events/ComplaintMessageEvent.php
+++ b/src/Events/ComplaintMessageEvent.php
@@ -2,9 +2,10 @@
 
 namespace jdavidbakr\MailTracker\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 
 class ComplaintMessageEvent implements ShouldQueue
 {
@@ -16,11 +17,10 @@ class ComplaintMessageEvent implements ShouldQueue
     /**
      * Create a new event instance.
      *
-     * @param  email_address  $email_address
-     * @param  sent_email  $sent_email
-     * @return void
+     * @param string $email_address
+     * @param Model|SentEmailModel|null $sent_email
      */
-    public function __construct($email_address, SentEmail $sent_email = null)
+    public function __construct($email_address, Model|SentEmailModel|null $sent_email = null)
     {
         $this->email_address = $email_address;
         $this->sent_email = $sent_email;

--- a/src/Events/EmailDeliveredEvent.php
+++ b/src/Events/EmailDeliveredEvent.php
@@ -2,9 +2,10 @@
 
 namespace jdavidbakr\MailTracker\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 
 class EmailDeliveredEvent implements ShouldQueue
 {
@@ -16,11 +17,10 @@ class EmailDeliveredEvent implements ShouldQueue
     /**
      * Create a new event instance.
      *
-     * @param  email_address  $email_address
-     * @param  sent_email  $sent_email
-     * @return void
+     * @param string $email_address
+     * @param Model|SentEmailModel|null $sent_email
      */
-    public function __construct($email_address, SentEmail $sent_email = null)
+    public function __construct($email_address, Model|SentEmailModel|null $sent_email = null)
     {
         $this->email_address = $email_address;
         $this->sent_email = $sent_email;

--- a/src/Events/EmailSentEvent.php
+++ b/src/Events/EmailSentEvent.php
@@ -2,9 +2,10 @@
 
 namespace jdavidbakr\MailTracker\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 
 class EmailSentEvent implements ShouldQueue
 {
@@ -15,10 +16,10 @@ class EmailSentEvent implements ShouldQueue
     /**
      * Create a new event instance.
      *
-     * @param  sent_email  $sent_email
+     * @param  Model|SentEmailModel  $sent_email
      * @return void
      */
-    public function __construct(SentEmail $sent_email)
+    public function __construct(Model|SentEmailModel $sent_email)
     {
         $this->sent_email = $sent_email;
     }

--- a/src/Events/LinkClickedEvent.php
+++ b/src/Events/LinkClickedEvent.php
@@ -2,9 +2,10 @@
 
 namespace jdavidbakr\MailTracker\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 
 class LinkClickedEvent implements ShouldQueue
 {
@@ -17,11 +18,11 @@ class LinkClickedEvent implements ShouldQueue
     /**
      * Create a new event instance.
      *
-     * @param SentEmail $sent_email
+     * @param Model|SentEmailModel $sent_email
      * @param string $ip_address
      * @param string $link_url
      */
-    public function __construct(SentEmail $sent_email, $ip_address, $link_url)
+    public function __construct(Model|SentEmailModel $sent_email, $ip_address, $link_url)
     {
         $this->sent_email = $sent_email;
         $this->ip_address = $ip_address;

--- a/src/Events/PermanentBouncedMessageEvent.php
+++ b/src/Events/PermanentBouncedMessageEvent.php
@@ -2,9 +2,10 @@
 
 namespace jdavidbakr\MailTracker\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 
 class PermanentBouncedMessageEvent implements ShouldQueue
 {
@@ -17,9 +18,9 @@ class PermanentBouncedMessageEvent implements ShouldQueue
      * Create a new event instance.
      *
      * @param string $email_address
-     * @param SentEmail|null $sent_email
+     * @param Model|SentEmailModel|null $sent_email
      */
-    public function __construct(string $email_address, SentEmail $sent_email = null)
+    public function __construct(string $email_address, Model|SentEmailModel|null $sent_email = null)
     {
         $this->email_address = $email_address;
         $this->sent_email = $sent_email;

--- a/src/Events/PermanentBouncedMessageEvent.php
+++ b/src/Events/PermanentBouncedMessageEvent.php
@@ -16,11 +16,10 @@ class PermanentBouncedMessageEvent implements ShouldQueue
     /**
      * Create a new event instance.
      *
-     * @param  email_address  $email_address
-     * @param  sent_email  $sent_email
-     * @return void
+     * @param string $email_address
+     * @param SentEmail|null $sent_email
      */
-    public function __construct($email_address, SentEmail $sent_email = null)
+    public function __construct(string $email_address, SentEmail $sent_email = null)
     {
         $this->email_address = $email_address;
         $this->sent_email = $sent_email;

--- a/src/Events/TransientBouncedMessageEvent.php
+++ b/src/Events/TransientBouncedMessageEvent.php
@@ -2,9 +2,10 @@
 
 namespace jdavidbakr\MailTracker\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 
 class TransientBouncedMessageEvent implements ShouldQueue
 {
@@ -18,11 +19,12 @@ class TransientBouncedMessageEvent implements ShouldQueue
     /**
      * Create a new event instance.
      *
-     * @param  email_address  $email_address
-     * @param  sent_email  $sent_email
-     * @return void
+     * @param string $email_address
+     * @param $bounce_sub_type
+     * @param $diagnostic_code
+     * @param Model|SentEmailModel|null $sent_email $sent_email
      */
-    public function __construct($email_address, $bounce_sub_type, $diagnostic_code, SentEmail $sent_email = null)
+    public function __construct($email_address, $bounce_sub_type, $diagnostic_code, Model|SentEmailModel|null $sent_email = null)
     {
         $this->email_address = $email_address;
         $this->sent_email = $sent_email;

--- a/src/Events/ViewEmailEvent.php
+++ b/src/Events/ViewEmailEvent.php
@@ -2,9 +2,10 @@
 
 namespace jdavidbakr\MailTracker\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\SerializesModels;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 
 class ViewEmailEvent implements ShouldQueue
 {
@@ -16,10 +17,10 @@ class ViewEmailEvent implements ShouldQueue
     /**
      * Create a new event instance.
      *
-     * @param  sent_email  $sent_email
-     * @return void
+     * @param Model|SentEmailModel $sent_email
+     * @param $ip_address
      */
-    public function __construct(SentEmail $sent_email, $ip_address)
+    public function __construct(Model|SentEmailModel $sent_email, $ip_address)
     {
         $this->sent_email = $sent_email;
         $this->ip_address = $ip_address;

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -9,6 +9,7 @@ use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\SentMessage;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 use jdavidbakr\MailTracker\Events\EmailSentEvent;
 use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
@@ -325,7 +326,7 @@ class MailTracker
                     'opens' => 0,
                     'clicks' => 0,
                     'message_id' => Str::uuid(),
-                ]), function(SentEmail $sentEmail) use ($original_html, $hash) {
+                ]), function(Model|SentEmailModel $sentEmail) use ($original_html, $hash) {
                     $sentEmail->fillContent($original_html, $hash);
 
                     $sentEmail->save();

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -346,8 +346,14 @@ class MailTracker
         if (config('mail-tracker.expire-days') > 0) {
             $emails = MailTracker::sentEmailModel()->newQuery()->where('created_at', '<', \Carbon\Carbon::now()
                 ->subDays(config('mail-tracker.expire-days')))
-                ->select('id')
+                ->select('id', 'meta')
                 ->get();
+            // remove files
+            $emails->each(function ($email) {
+                if ($email->meta && ($filePath = $email->meta->get('content_file_path'))) {
+                    Storage::disk(config('mail-tracker.tracker-filesystem'))->delete($filePath);
+                }
+            });
             MailTracker::sentEmailUrlClickedModel()->newQuery()->whereIn('sent_email_id', $emails->pluck('id'))->delete();
             MailTracker::sentEmailModel()->newQuery()->whereIn('id', $emails->pluck('id'))->delete();
         }

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -3,6 +3,7 @@
 namespace jdavidbakr\MailTracker;
 
 use Closure;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\SentMessage;
@@ -30,6 +31,20 @@ class MailTracker
     protected Closure $messageIdResolver;
 
     /**
+     * The SentEmail model class name.
+     *
+     * @var string
+     */
+    protected static string $sentEmailModel = SentEmail::class;
+
+    /**
+     * The SentEmailUrlClicked model class name.
+     *
+     * @var string
+     */
+    protected static string $sentEmailUrlClickedModel = SentEmailUrlClicked::class;
+
+    /**
      * Configure this library to not register its migrations.
      *
      * @return static
@@ -39,6 +54,49 @@ class MailTracker
         static::$runsMigrations = false;
 
         return new static;
+    }
+
+    /**
+     * Set class name of SentEmail model.
+     *
+     * @param string $sentEmailModelClass
+     * @return void
+     */
+    public static function useSentEmailModel(string $sentEmailModelClass): void {
+        static::$sentEmailModel = $sentEmailModelClass;
+    }
+
+    /**
+     * Create new SentEmail model.
+     *
+     * @param array $attributes
+     * @return Model|SentEmail
+     */
+    public static function newSentEmailModel(array $attributes = []): Model|SentEmail
+    {
+        return new static::$sentEmailModel($attributes);
+    }
+
+    /**
+     * Set class name of SentEmailUrlClicked model.
+     *
+     * @param string $class
+     * @return void
+     */
+    public static function useSentEmailUrlClickedModel(string $class): void
+    {
+        static::$sentEmailUrlClickedModel = $class;
+    }
+
+    /**
+     * Create new SentEmailUrlClicked model.
+     *
+     * @param array $attributes
+     * @return Model|SentEmailUrlClicked
+     */
+    public static function newSentEmailUrlClickedModel(array $attributes = []): Model|SentEmailUrlClicked
+    {
+        return new static::$sentEmailUrlClickedModel($attributes);
     }
 
     /**

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -35,14 +35,14 @@ class MailTracker
      *
      * @var string
      */
-    protected static string $sentEmailModel = SentEmail::class;
+    public static string $sentEmailModel = SentEmail::class;
 
     /**
      * The SentEmailUrlClicked model class name.
      *
      * @var string
      */
-    protected static string $sentEmailUrlClickedModel = SentEmailUrlClicked::class;
+    public static string $sentEmailUrlClickedModel = SentEmailUrlClicked::class;
 
     /**
      * Configure this library to not register its migrations.

--- a/src/MailTrackerController.php
+++ b/src/MailTrackerController.php
@@ -28,7 +28,7 @@ class MailTrackerController extends Controller
         $response->header('Last-Modified', 'Wed, 11 Jan 2006 12:59:00 GMT');
         $response->header('Pragma', 'no-cache');
 
-        $tracker = MailTracker::newSentEmailModel()->newQuery()->where('hash', $hash)
+        $tracker = MailTracker::sentEmailModel()->newQuery()->where('hash', $hash)
             ->first();
         if ($tracker) {
             RecordTrackingJob::dispatch($tracker, request()->ip())
@@ -63,7 +63,7 @@ class MailTrackerController extends Controller
         if (!$url) {
             $url = config('mail-tracker.redirect-missing-links-to') ?: '/';
         }
-        $tracker = MailTracker::newSentEmailModel()->newQuery()->where('hash', $hash)
+        $tracker = MailTracker::sentEmailModel()->newQuery()->where('hash', $hash)
             ->first();
         if ($tracker) {
             RecordLinkClickJob::dispatch($tracker, $url, request()->ip())

--- a/src/MailTrackerController.php
+++ b/src/MailTrackerController.php
@@ -28,7 +28,7 @@ class MailTrackerController extends Controller
         $response->header('Last-Modified', 'Wed, 11 Jan 2006 12:59:00 GMT');
         $response->header('Pragma', 'no-cache');
 
-        $tracker = Model\SentEmail::where('hash', $hash)
+        $tracker = MailTracker::newSentEmailModel()->newQuery()->where('hash', $hash)
             ->first();
         if ($tracker) {
             RecordTrackingJob::dispatch($tracker, request()->ip())
@@ -63,7 +63,7 @@ class MailTrackerController extends Controller
         if (!$url) {
             $url = config('mail-tracker.redirect-missing-links-to') ?: '/';
         }
-        $tracker = Model\SentEmail::where('hash', $hash)
+        $tracker = MailTracker::newSentEmailModel()->newQuery()->where('hash', $hash)
             ->first();
         if ($tracker) {
             RecordLinkClickJob::dispatch($tracker, $url, request()->ip())

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -47,11 +47,10 @@ class SentEmail extends Model
         'clicked_at' => 'datetime',
     ];
 
-    protected static function boot()
+    protected static function booted()
     {
-        parent::boot();
-        static::deleting(function ($email) {
-            if ($email->meta && ($filePath = $email->meta->get('content_file_path'))) {
+        static::deleting(function (self $email) {
+            if ($filePath = $email->meta?->get('content_file_path')) {
                 Storage::disk(config('mail-tracker.tracker-filesystem'))->delete($filePath);
             }
         });

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use jdavidbakr\MailTracker\MailTracker;
 
 /**
  * @property string $hash
@@ -169,7 +170,7 @@ class SentEmail extends Model
 
     public function urlClicks()
     {
-        return $this->hasMany(SentEmailUrlClicked::class);
+        return $this->hasMany(MailTracker::$sentEmailUrlClickedModel);
     }
 
     public function fillContent(string $originalHtml, string $hash)

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -2,13 +2,10 @@
 
 namespace jdavidbakr\MailTracker\Model;
 
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
-use jdavidbakr\MailTracker\MailTracker;
+use jdavidbakr\MailTracker\Concerns\IsSentEmailModel;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 
 /**
  * @property string $hash
@@ -22,8 +19,10 @@ use jdavidbakr\MailTracker\MailTracker;
  * @property int|null $message_id
  * @property Collection $meta
  */
-class SentEmail extends Model
+class SentEmail extends Model implements SentEmailModel
 {
+    use IsSentEmailModel;
+
     protected $fillable = [
         'hash',
         'headers',
@@ -46,184 +45,4 @@ class SentEmail extends Model
         'opened_at' => 'datetime',
         'clicked_at' => 'datetime',
     ];
-
-    protected static function booted()
-    {
-        static::deleting(function (self $email) {
-            if ($filePath = $email->meta?->get('content_file_path')) {
-                Storage::disk(config('mail-tracker.tracker-filesystem'))->delete($filePath);
-            }
-        });
-    }
-
-    public function getConnectionName()
-    {
-        $connName = config('mail-tracker.connection');
-        return $connName ?: config('database.default');
-    }
-
-    /**
-     * Returns a bootstrap class about the success/failure of the message
-     * @return [type] [description]
-     */
-    public function getReportClassAttribute()
-    {
-        if (!empty($this->meta) && $this->meta->has('success')) {
-            if ($this->meta->get('success')) {
-                return 'success';
-            } else {
-                return 'danger';
-            }
-        } else {
-            return '';
-        }
-    }
-
-    public function getSenderAttribute()
-    {
-        return $this->sender_name.' <'.$this->sender_email.'>';
-    }
-
-    public function getRecipientAttribute()
-    {
-        return $this->recipient_name.' <'.$this->recipient_email.'>';
-    }
-
-    /**
-     * Returns the smtp detail for this message ()
-     * @return [type] [description]
-     */
-    public function getSmtpInfoAttribute()
-    {
-        if (empty($this->meta)) {
-            return '';
-        }
-        $meta = $this->meta;
-        $responses = [];
-        if ($meta->has('smtpResponse')) {
-            $response = $meta->get('smtpResponse');
-            $delivered_at = $meta->get('delivered_at');
-            $responses[] = $response.' - Delivered '.$delivered_at;
-        }
-        if ($meta->has('failures')) {
-            foreach ($meta->get('failures') as $failure) {
-                if (!empty($failure['status'])) {
-                    $responses[] = $failure['status'].' ('.$failure['action'].'): '.$failure['diagnosticCode'].' ('.$failure['emailAddress'].')';
-                } else {
-                    $responses[] = 'Generic Failure ('.$failure['emailAddress'].')';
-                }
-            }
-        } elseif ($meta->has('complaint')) {
-            $complaint_time = $meta->get('complaint_time');
-            if ($meta->get('complaint_type')) {
-                $responses[] = 'Complaint: '.$meta->get('complaint_type').' at '.$complaint_time;
-            } else {
-                $responses[] = 'Complaint at '.$complaint_time->format("n/d/y g:i a");
-            }
-        }
-        return implode(" | ", $responses);
-    }
-
-    /**
-     * Get content according to log-content-strategy.
-     * @return string|null
-     */
-    public function getContentAttribute(): ?string
-    {
-        if ($content = $this->attributes['content']) {
-            return $content;
-        }
-        if ($contentFilePath = $this->meta->get('content_file_path')) {
-            try {
-                return Storage::disk(config('mail-tracker.tracker-filesystem'))->get($contentFilePath);
-            } catch (FileNotFoundException $e) {
-                return null;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Returns a collection of all headers requested from our stored header info
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function getAllHeaders()
-    {
-        return collect(preg_split("/(\r\n)(?!\s)/", $this->headers))
-            ->filter(function ($header) {
-                return preg_match("/:/", $header);
-            })
-            ->transform(function ($header) {
-                $header = Str::replace("\r\n", '', $header);
-                list($key, $value) = explode(":", $header, 2);
-                return collect([
-                    'key' => trim($key),
-                    'value' => trim($value)
-                ]);
-            })->filter(function ($header) {
-                return $header->get('key');
-            })->keyBy('key')
-            ->transform(function ($header) {
-                return $header->get('value');
-            });
-    }
-
-    /**
-     * Returns the header requested from our stored header info
-     */
-    public function getHeader($key)
-    {
-        return $this->getAllHeaders()->get($key);
-    }
-
-    public function urlClicks()
-    {
-        return $this->hasMany(MailTracker::$sentEmailUrlClickedModel);
-    }
-
-    public function fillContent(string $originalHtml, string $hash)
-    {
-        $logContent = config('mail-tracker.log-content', true);
-
-        if(!$logContent) {
-            return;
-        }
-
-        $logContentStrategy = config('mail-tracker.log-content-strategy', 'database');
-
-        if(!in_array($logContentStrategy, ['database', 'filesystem'])) {
-            return;
-        }
-
-        $databaseContent = null;
-
-        // handling filesystem strategy
-        if ($logContentStrategy === 'filesystem') {
-            // store body in html file
-            $basePath = config('mail-tracker.tracker-filesystem-folder', 'mail-tracker');
-            $fileSystem = config('mail-tracker.tracker-filesystem');
-            $contentFilePath = "{$basePath}/{$hash}.html";
-
-            try {
-                Storage::disk($fileSystem)->put($contentFilePath, $originalHtml);
-            } catch (\Exception $e) {
-                Log::warning($e->getMessage());
-                // fail silently
-            }
-
-            $meta = collect($this->meta);
-            $meta->put('content_file_path', $contentFilePath);
-            $this->meta = $meta;
-        }
-
-        // handling database strategy
-        if ($logContentStrategy === 'database') {
-            $databaseContent = Str::length($originalHtml) > config('mail-tracker.content-max-size', 65535)
-                ? Str::substr($originalHtml, 0, config('mail-tracker.content-max-size', 65535)) . '...'
-                : $originalHtml;
-        }
-
-        $this->content = $databaseContent;
-    }
 }

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -47,6 +47,16 @@ class SentEmail extends Model
         'clicked_at' => 'datetime',
     ];
 
+    protected static function boot()
+    {
+        parent::boot();
+        static::deleting(function ($email) {
+            if ($email->meta && ($filePath = $email->meta->get('content_file_path'))) {
+                Storage::disk(config('mail-tracker.tracker-filesystem'))->delete($filePath);
+            }
+        });
+    }
+
     public function getConnectionName()
     {
         $connName = config('mail-tracker.connection');

--- a/src/Model/SentEmailUrlClicked.php
+++ b/src/Model/SentEmailUrlClicked.php
@@ -3,12 +3,14 @@
 namespace jdavidbakr\MailTracker\Model;
 
 use Illuminate\Database\Eloquent\Model;
-use jdavidbakr\MailTracker\MailTracker;
+use jdavidbakr\MailTracker\Concerns\IsSentEmailUrlClickedModel;
+use jdavidbakr\MailTracker\Contracts\SentEmailUrlClickedModel;
 
-// use Model\SentEmail;
 
-class SentEmailUrlClicked extends Model
+class SentEmailUrlClicked extends Model implements SentEmailUrlClickedModel
 {
+    use IsSentEmailUrlClickedModel;
+
     protected $table = 'sent_emails_url_clicked';
 
     protected $fillable = [
@@ -17,15 +19,4 @@ class SentEmailUrlClicked extends Model
         'hash',
         'clicks',
     ];
-
-    public function getConnectionName()
-    {
-        $connName = config('mail-tracker.connection');
-        return $connName ?: config('database.default');
-    }
-
-    public function email()
-    {
-        return $this->belongsTo(MailTracker::$sentEmailModel, 'sent_email_id');
-    }
 }

--- a/src/Model/SentEmailUrlClicked.php
+++ b/src/Model/SentEmailUrlClicked.php
@@ -3,6 +3,7 @@
 namespace jdavidbakr\MailTracker\Model;
 
 use Illuminate\Database\Eloquent\Model;
+use jdavidbakr\MailTracker\MailTracker;
 
 // use Model\SentEmail;
 
@@ -25,6 +26,6 @@ class SentEmailUrlClicked extends Model
 
     public function email()
     {
-        return $this->belongsTo(SentEmail::class, 'sent_email_id');
+        return $this->belongsTo(MailTracker::$sentEmailModel, 'sent_email_id');
     }
 }

--- a/src/RecordBounceJob.php
+++ b/src/RecordBounceJob.php
@@ -32,7 +32,7 @@ class RecordBounceJob implements ShouldQueue
 
     public function handle()
     {
-        $sent_email = MailTracker::newSentEmailModel()->newQuery()->where('message_id', $this->message->mail->messageId)->first();
+        $sent_email = MailTracker::sentEmailModel()->newQuery()->where('message_id', $this->message->mail->messageId)->first();
         if ($sent_email) {
             $meta = collect($sent_email->meta);
             $current_codes = [];

--- a/src/RecordBounceJob.php
+++ b/src/RecordBounceJob.php
@@ -10,7 +10,6 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Event;
 use jdavidbakr\MailTracker\Events\PermanentBouncedMessageEvent;
 use jdavidbakr\MailTracker\Events\TransientBouncedMessageEvent;
-use jdavidbakr\MailTracker\Model\SentEmail;
 
 class RecordBounceJob implements ShouldQueue
 {
@@ -33,7 +32,7 @@ class RecordBounceJob implements ShouldQueue
 
     public function handle()
     {
-        $sent_email = SentEmail::where('message_id', $this->message->mail->messageId)->first();
+        $sent_email = MailTracker::newSentEmailModel()->newQuery()->where('message_id', $this->message->mail->messageId)->first();
         if ($sent_email) {
             $meta = collect($sent_email->meta);
             $current_codes = [];

--- a/src/RecordComplaintJob.php
+++ b/src/RecordComplaintJob.php
@@ -8,7 +8,6 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Events\ComplaintMessageEvent;
 
 class RecordComplaintJob implements ShouldQueue
@@ -32,7 +31,7 @@ class RecordComplaintJob implements ShouldQueue
 
     public function handle()
     {
-        $sent_email = SentEmail::where('message_id', $this->message->mail->messageId)->first();
+        $sent_email = MailTracker::newSentEmailModel()->newQuery()->where('message_id', $this->message->mail->messageId)->first();
         if ($sent_email) {
             $meta = collect($sent_email->meta);
             $meta->put('complaint', true);

--- a/src/RecordComplaintJob.php
+++ b/src/RecordComplaintJob.php
@@ -31,7 +31,7 @@ class RecordComplaintJob implements ShouldQueue
 
     public function handle()
     {
-        $sent_email = MailTracker::newSentEmailModel()->newQuery()->where('message_id', $this->message->mail->messageId)->first();
+        $sent_email = MailTracker::sentEmailModel()->newQuery()->where('message_id', $this->message->mail->messageId)->first();
         if ($sent_email) {
             $meta = collect($sent_email->meta);
             $meta->put('complaint', true);

--- a/src/RecordDeliveryJob.php
+++ b/src/RecordDeliveryJob.php
@@ -8,7 +8,6 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Events\EmailDeliveredEvent;
 
 class RecordDeliveryJob implements ShouldQueue
@@ -32,7 +31,7 @@ class RecordDeliveryJob implements ShouldQueue
 
     public function handle()
     {
-        $sent_email = SentEmail::where('message_id', $this->message->mail->messageId)->first();
+        $sent_email = MailTracker::newSentEmailModel()->newQuery()->where('message_id', $this->message->mail->messageId)->first();
         if ($sent_email) {
             $meta = collect($sent_email->meta);
             $meta->put('smtpResponse', $this->message->delivery->smtpResponse);

--- a/src/RecordDeliveryJob.php
+++ b/src/RecordDeliveryJob.php
@@ -31,7 +31,7 @@ class RecordDeliveryJob implements ShouldQueue
 
     public function handle()
     {
-        $sent_email = MailTracker::newSentEmailModel()->newQuery()->where('message_id', $this->message->mail->messageId)->first();
+        $sent_email = MailTracker::sentEmailModel()->newQuery()->where('message_id', $this->message->mail->messageId)->first();
         if ($sent_email) {
             $meta = collect($sent_email->meta);
             $meta->put('smtpResponse', $this->message->delivery->smtpResponse);

--- a/src/RecordLinkClickJob.php
+++ b/src/RecordLinkClickJob.php
@@ -8,10 +8,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\Events\LinkClickedEvent;
-use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
-use jdavidbakr\MailTracker\Events\EmailDeliveredEvent;
 
 class RecordLinkClickJob implements ShouldQueue
 {
@@ -40,12 +37,12 @@ class RecordLinkClickJob implements ShouldQueue
     {
         $this->sentEmail->clicks++;
         $this->sentEmail->save();
-        $url_clicked = SentEmailUrlClicked::where('url', $this->url)->where('hash', $this->sentEmail->hash)->first();
+        $url_clicked = MailTracker::newSentEmailUrlClickedModel()->newQuery()->where('url', $this->url)->where('hash', $this->sentEmail->hash)->first();
         if ($url_clicked) {
             $url_clicked->clicks++;
             $url_clicked->save();
         } else {
-            $url_clicked = SentEmailUrlClicked::create([
+            $url_clicked = MailTracker::newSentEmailUrlClickedModel()->newQuery()->create([
                 'sent_email_id' => $this->sentEmail->id,
                 'url' => $this->url,
                 'hash' => $this->sentEmail->hash,

--- a/src/RecordLinkClickJob.php
+++ b/src/RecordLinkClickJob.php
@@ -37,12 +37,12 @@ class RecordLinkClickJob implements ShouldQueue
     {
         $this->sentEmail->clicks++;
         $this->sentEmail->save();
-        $url_clicked = MailTracker::newSentEmailUrlClickedModel()->newQuery()->where('url', $this->url)->where('hash', $this->sentEmail->hash)->first();
+        $url_clicked = MailTracker::sentEmailUrlClickedModel()->newQuery()->where('url', $this->url)->where('hash', $this->sentEmail->hash)->first();
         if ($url_clicked) {
             $url_clicked->clicks++;
             $url_clicked->save();
         } else {
-            $url_clicked = MailTracker::newSentEmailUrlClickedModel()->newQuery()->create([
+            $url_clicked = MailTracker::sentEmailUrlClickedModel()->newQuery()->create([
                 'sent_email_id' => $this->sentEmail->id,
                 'url' => $this->url,
                 'hash' => $this->sentEmail->hash,

--- a/src/RecordTrackingJob.php
+++ b/src/RecordTrackingJob.php
@@ -3,16 +3,12 @@
 namespace jdavidbakr\MailTracker;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Event;
 use jdavidbakr\MailTracker\Events\ViewEmailEvent;
-use jdavidbakr\MailTracker\Events\LinkClickedEvent;
-use jdavidbakr\MailTracker\Model\SentEmailUrlClicked;
-use jdavidbakr\MailTracker\Events\EmailDeliveredEvent;
 
 class RecordTrackingJob implements ShouldQueue
 {

--- a/src/SNSController.php
+++ b/src/SNSController.php
@@ -9,7 +9,6 @@ use Illuminate\Http\Request;
 use GuzzleHttp\Client as Guzzle;
 use Aws\Sns\Message as SNSMessage;
 use Illuminate\Routing\Controller;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\RecordBounceJob;
 use jdavidbakr\MailTracker\RecordDeliveryJob;
 use jdavidbakr\MailTracker\RecordComplaintJob;

--- a/tests/DeleteFileTest.php
+++ b/tests/DeleteFileTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Tests;
+
+use Illuminate\Support\Facades\Storage;
+use jdavidbakr\MailTracker\Model\SentEmail;
+
+class DeleteFileTest extends SetUpTest
+{
+
+    /** @test */
+    public function it_deletes_file_after_model_is_deleted()
+    {
+        $disk = 'testing';
+        config([
+            'mail-tracker.log-content-strategy' => 'filesystem',
+            'mail-tracker.tracker-filesystem' => $disk,
+            'mail-tracker.tracker-filesystem-folder' => 'mail-tracker',
+            'filesystems.disks.testing.driver' => 'local',
+            'filesystems.default' => 'testing',
+        ]);
+
+        Storage::fake($disk);
+
+        // create model and file
+        $filePath = 'mail-tracker/random-hash.html';
+        $sentEmail = SentEmail::query()->create([
+            'hash' => 'random-hash',
+            'sender_name' => 'From Name',
+            'sender_email' => 'from@johndoe.com',
+            'recipient_name' => 'name',
+            'recipient_email' => 'email@test.com',
+            'content' => null,
+            'meta' => collect(['content_file_path' => $filePath])
+        ]);
+
+        Storage::disk($disk)->put($filePath, 'html-content of email');
+        $sentEmail->delete();
+
+        Storage::assertMissing($filePath);
+    }
+}

--- a/tests/MailTrackerTest.php
+++ b/tests/MailTrackerTest.php
@@ -5,6 +5,7 @@ namespace jdavidbakr\MailTracker\Tests;
 use Exception;
 use Faker\Factory;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\Mailable;
@@ -1264,4 +1265,52 @@ class MailTrackerTest extends SetUpTest
         $this->assertEquals($expectedPath, $filePath);
         Storage::disk(config('mail-tracker.tracker-filesystem'))->assertExists($filePath);
     }
+
+    /** @test */
+    public function sent_email_model_can_be_created()
+    {
+        $sentEmail = MailTracker::sentEmailModel();
+
+        $this->assertInstanceOf(SentEmail::class, $sentEmail);
+    }
+
+    /** @test */
+    public function sent_email_model_can_be_changed()
+    {
+        MailTracker::useSentEmailModel(SentEmailStub::class);
+
+        $sentEmail = MailTracker::sentEmailModel();
+
+        $this->assertInstanceOf(SentEmailStub::class, $sentEmail);
+
+        MailTracker::useSentEmailModel(SentEmail::class);
+    }
+
+    /** @test */
+    public function sent_email_url_clicked_model_can_be_created()
+    {
+        $sentEmailUrlClicked = MailTracker::sentEmailUrlClickedModel();
+
+        $this->assertInstanceOf(SentEmailUrlClicked::class, $sentEmailUrlClicked);
+    }
+
+    /** @test */
+    public function sent_email_url_clicked_model_can_be_changed()
+    {
+        MailTracker::useSentEmailUrlClickedModel(SentEmailUrlClickedStub::class);
+
+        $sentEmailUrlClicked = MailTracker::sentEmailUrlClickedModel();
+
+        $this->assertInstanceOf(SentEmailUrlClickedStub::class, $sentEmailUrlClicked);
+
+        MailTracker::useSentEmailUrlClickedModel(SentEmailUrlClicked::class);
+    }
+}
+
+class SentEmailStub extends Model
+{
+}
+
+class SentEmailUrlClickedStub extends Model
+{
 }

--- a/tests/MailTrackerTest.php
+++ b/tests/MailTrackerTest.php
@@ -73,10 +73,10 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail-tracker.inject-pixel', 1);
         Config::set('mail-tracker.track-links', 1);
 
-        $old_email = SentEmail::create([
+        $old_email = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
             ]);
-        $old_url = SentEmailUrlClicked::create([
+        $old_url = MailTracker::newSentEmailUrlClickedModel()->newQuery()->create([
                 'sent_email_id' => $old_email->id,
                 'hash' => Str::random(32),
             ]);
@@ -128,7 +128,7 @@ class MailTrackerTest extends SetUpTest
                 'opened_at' => null,
                 'clicked_at' => null,
             ]);
-        $sent_email = SentEmail::where([
+        $sent_email = MailTracker::newSentEmailModel()->where([
             'hash' => 'random-hash',
         ])->first();
         $this->assertEquals($name.' <'.$email.'>', $sent_email->recipient);
@@ -339,7 +339,7 @@ class MailTrackerTest extends SetUpTest
         Carbon::setTestNow(now());
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
             ]);
         $pings = $track->opens;
@@ -368,7 +368,7 @@ class MailTrackerTest extends SetUpTest
         Carbon::setTestNow(now());
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
                 'opened_at' => now()->subDays(10),
             ]);
@@ -395,7 +395,7 @@ class MailTrackerTest extends SetUpTest
         Carbon::setTestNow(now());
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
             ]);
         $clicks = $track->clicks;
@@ -426,7 +426,7 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail-tracker.inject-pixel', true);
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
             ]);
         $redirect = 'http://'.Str::random(15).'.com/'.Str::random(10).'/'.Str::random(10).'/'.rand(0, 100).'/'.rand(0, 100).'?page='.rand(0, 100).'&x='.Str::random(32);
@@ -456,7 +456,7 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_redirects_even_if_no_sent_email_exists()
     {
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
             ]);
 
@@ -519,7 +519,7 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_retrieves_the_mesage_id_from_laravel_mailer()
     {
-        $sent = SentEmail::create([
+        $sent = MailTracker::newSentEmailModel()->create([
             'hash'=>'the-hash',
             'message_id'=>'to-be-replaced',
         ]);
@@ -576,7 +576,7 @@ class MailTrackerTest extends SetUpTest
     {
         Config::set('mail.default', 'ses');
         Config::set('mail.driver', null);
-        $sent = SentEmail::create([
+        $sent = MailTracker::newSentEmailModel()->create([
             'hash'=>'the-hash',
             'message_id'=>'to-be-replaced',
         ]);
@@ -638,7 +638,7 @@ class MailTrackerTest extends SetUpTest
             ->andReturn('random-hash');
         Config::set('mail.driver', 'ses');
         Config::set('mail.default', null);
-        $sent = SentEmail::create([
+        $sent = MailTracker::newSentEmailModel()->create([
             'hash'=>'the-hash',
             'message_id'=>'to-be-replaced',
         ]);
@@ -922,7 +922,7 @@ class MailTrackerTest extends SetUpTest
             'clicks' => 1,
         ]);
 
-        $track = SentEmail::whereHash($hash)->first();
+        $track = MailTracker::newSentEmailModel()->whereHash($hash)->first();
         $this->assertNotNull($track);
         $this->assertEquals(1, $track->clicks);
     }
@@ -980,7 +980,7 @@ class MailTrackerTest extends SetUpTest
             'clicks' => 1,
         ]);
 
-        $track = SentEmail::whereHash($hash)->first();
+        $track = MailTracker::newSentEmailModel()->whereHash($hash)->first();
         $this->assertNotNull($track);
         $this->assertEquals(1, $track->clicks);
     }
@@ -1018,7 +1018,7 @@ class MailTrackerTest extends SetUpTest
         } catch (TransportException $e) {
         }
 
-        $track = SentEmail::orderBy('id', 'desc')->first();
+        $track = MailTracker::newSentEmailModel()->orderBy('id', 'desc')->first();
         $this->assertEquals($header_test, $track->getHeader('X-Header-Test'));
     }
 
@@ -1054,7 +1054,7 @@ class MailTrackerTest extends SetUpTest
         } catch (TransportException $e) {
         }
 
-        $track = SentEmail::orderBy('id', 'desc')->first();
+        $track = MailTracker::newSentEmailModel()->orderBy('id', 'desc')->first();
         $this->assertEquals($header_test, $track->getHeader('X-Header-Test'));
     }
 
@@ -1095,7 +1095,7 @@ class MailTrackerTest extends SetUpTest
         } catch (TransportException $e) {
         }
 
-        $track = SentEmail::orderBy('id', 'desc')->first();
+        $track = MailTracker::newSentEmailModel()->orderBy('id', 'desc')->first();
 
         $this->assertEquals(
             'CC This Person With a Long Name 1 <cc.averylongemail1@johndoe.com>, ' .
@@ -1123,10 +1123,10 @@ class MailTrackerTest extends SetUpTest
         $this->app['migrator']->setConnection('secondary');
         $this->artisan('migrate', ['--database' => 'secondary']);
 
-        $old_email = SentEmail::create([
+        $old_email = MailTracker::newSentEmailModel()->create([
             'hash' => Str::random(32),
         ]);
-        $old_url = SentEmailUrlClicked::create([
+        $old_url = MailTracker::newSentEmailUrlClickedModel()->newQuery()->create([
             'sent_email_id' => $old_email->id,
             'hash' => Str::random(32),
         ]);
@@ -1180,14 +1180,14 @@ class MailTrackerTest extends SetUpTest
     public function it_can_retrieve_url_clicks_from_eloquent()
     {
         Event::fake();
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
             'hash' => Str::random(32),
         ]);
         $message_id = Str::random(32);
         $track->message_id = $message_id;
         $track->save();
 
-        $urlClick = SentEmailUrlClicked::create([
+        $urlClick = MailTracker::newSentEmailUrlClickedModel()->newQuery()->create([
             'sent_email_id' => $track->id,
             'url' => 'https://example.com',
             'hash' => Str::random(32)
@@ -1195,7 +1195,7 @@ class MailTrackerTest extends SetUpTest
         $urlClick->save();
         $this->assertTrue($track->urlClicks->count() === 1);
         $this->assertInstanceOf(\Illuminate\Support\Collection::class, $track->urlClicks);
-        $this->assertInstanceOf(SentEmailUrlClicked::class, $track->urlClicks->first());
+        $this->assertInstanceOf(MailTracker::$sentEmailUrlClickedModel, $track->urlClicks->first());
     }
 
     /**
@@ -1204,7 +1204,7 @@ class MailTrackerTest extends SetUpTest
     public function it_handles_headers_with_colons()
     {
         $headerData = '{"some_id":2,"some_othger_id":"0dd75231-31bb-4e67-8ab7-a83315f75a44","some_field":"A Field Value"}';
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
             'hash' => Str::random(32),
             'headers' => 'X-MyHeader: '.$headerData,
         ]);
@@ -1255,7 +1255,7 @@ class MailTrackerTest extends SetUpTest
             'content' => null
         ]);
 
-        $tracker = SentEmail::query()->where('hash', '=','random-hash')->first();
+        $tracker = MailTracker::newSentEmailModel()->newQuery()->where('hash', '=','random-hash')->first();
         $this->assertNotNull($tracker);
         $this->assertEquals($content, $tracker->content);
         $folder = config('mail-tracker.tracker-filesystem-folder', 'mail-tracker');

--- a/tests/MailTrackerTest.php
+++ b/tests/MailTrackerTest.php
@@ -73,7 +73,7 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail-tracker.inject-pixel', 1);
         Config::set('mail-tracker.track-links', 1);
 
-        $old_email = MailTracker::newSentEmailModel()->create([
+        $old_email = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $old_url = MailTracker::newSentEmailUrlClickedModel()->newQuery()->create([
@@ -128,7 +128,7 @@ class MailTrackerTest extends SetUpTest
                 'opened_at' => null,
                 'clicked_at' => null,
             ]);
-        $sent_email = MailTracker::newSentEmailModel()->where([
+        $sent_email = MailTracker::newSentEmailModel()->newQuery()->where([
             'hash' => 'random-hash',
         ])->first();
         $this->assertEquals($name.' <'.$email.'>', $sent_email->recipient);
@@ -339,7 +339,7 @@ class MailTrackerTest extends SetUpTest
         Carbon::setTestNow(now());
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $pings = $track->opens;
@@ -368,7 +368,7 @@ class MailTrackerTest extends SetUpTest
         Carbon::setTestNow(now());
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
                 'opened_at' => now()->subDays(10),
             ]);
@@ -395,7 +395,7 @@ class MailTrackerTest extends SetUpTest
         Carbon::setTestNow(now());
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $clicks = $track->clicks;
@@ -426,7 +426,7 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail-tracker.inject-pixel', true);
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $redirect = 'http://'.Str::random(15).'.com/'.Str::random(10).'/'.Str::random(10).'/'.rand(0, 100).'/'.rand(0, 100).'?page='.rand(0, 100).'&x='.Str::random(32);
@@ -456,7 +456,7 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_redirects_even_if_no_sent_email_exists()
     {
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
 
@@ -519,7 +519,7 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_retrieves_the_mesage_id_from_laravel_mailer()
     {
-        $sent = MailTracker::newSentEmailModel()->create([
+        $sent = MailTracker::newSentEmailModel()->newQuery()->create([
             'hash'=>'the-hash',
             'message_id'=>'to-be-replaced',
         ]);
@@ -576,7 +576,7 @@ class MailTrackerTest extends SetUpTest
     {
         Config::set('mail.default', 'ses');
         Config::set('mail.driver', null);
-        $sent = MailTracker::newSentEmailModel()->create([
+        $sent = MailTracker::newSentEmailModel()->newQuery()->create([
             'hash'=>'the-hash',
             'message_id'=>'to-be-replaced',
         ]);
@@ -638,7 +638,7 @@ class MailTrackerTest extends SetUpTest
             ->andReturn('random-hash');
         Config::set('mail.driver', 'ses');
         Config::set('mail.default', null);
-        $sent = MailTracker::newSentEmailModel()->create([
+        $sent = MailTracker::newSentEmailModel()->newQuery()->create([
             'hash'=>'the-hash',
             'message_id'=>'to-be-replaced',
         ]);
@@ -922,7 +922,7 @@ class MailTrackerTest extends SetUpTest
             'clicks' => 1,
         ]);
 
-        $track = MailTracker::newSentEmailModel()->whereHash($hash)->first();
+        $track = MailTracker::newSentEmailModel()->newQuery()->whereHash($hash)->first();
         $this->assertNotNull($track);
         $this->assertEquals(1, $track->clicks);
     }
@@ -980,7 +980,7 @@ class MailTrackerTest extends SetUpTest
             'clicks' => 1,
         ]);
 
-        $track = MailTracker::newSentEmailModel()->whereHash($hash)->first();
+        $track = MailTracker::newSentEmailModel()->newQuery()->whereHash($hash)->first();
         $this->assertNotNull($track);
         $this->assertEquals(1, $track->clicks);
     }
@@ -1018,7 +1018,7 @@ class MailTrackerTest extends SetUpTest
         } catch (TransportException $e) {
         }
 
-        $track = MailTracker::newSentEmailModel()->orderBy('id', 'desc')->first();
+        $track = MailTracker::newSentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
         $this->assertEquals($header_test, $track->getHeader('X-Header-Test'));
     }
 
@@ -1054,7 +1054,7 @@ class MailTrackerTest extends SetUpTest
         } catch (TransportException $e) {
         }
 
-        $track = MailTracker::newSentEmailModel()->orderBy('id', 'desc')->first();
+        $track = MailTracker::newSentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
         $this->assertEquals($header_test, $track->getHeader('X-Header-Test'));
     }
 
@@ -1095,7 +1095,7 @@ class MailTrackerTest extends SetUpTest
         } catch (TransportException $e) {
         }
 
-        $track = MailTracker::newSentEmailModel()->orderBy('id', 'desc')->first();
+        $track = MailTracker::newSentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
 
         $this->assertEquals(
             'CC This Person With a Long Name 1 <cc.averylongemail1@johndoe.com>, ' .
@@ -1123,7 +1123,7 @@ class MailTrackerTest extends SetUpTest
         $this->app['migrator']->setConnection('secondary');
         $this->artisan('migrate', ['--database' => 'secondary']);
 
-        $old_email = MailTracker::newSentEmailModel()->create([
+        $old_email = MailTracker::newSentEmailModel()->newQuery()->create([
             'hash' => Str::random(32),
         ]);
         $old_url = MailTracker::newSentEmailUrlClickedModel()->newQuery()->create([
@@ -1180,7 +1180,7 @@ class MailTrackerTest extends SetUpTest
     public function it_can_retrieve_url_clicks_from_eloquent()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
             'hash' => Str::random(32),
         ]);
         $message_id = Str::random(32);
@@ -1204,7 +1204,7 @@ class MailTrackerTest extends SetUpTest
     public function it_handles_headers_with_colons()
     {
         $headerData = '{"some_id":2,"some_othger_id":"0dd75231-31bb-4e67-8ab7-a83315f75a44","some_field":"A Field Value"}';
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
             'hash' => Str::random(32),
             'headers' => 'X-MyHeader: '.$headerData,
         ]);

--- a/tests/MailTrackerTest.php
+++ b/tests/MailTrackerTest.php
@@ -73,10 +73,10 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail-tracker.inject-pixel', 1);
         Config::set('mail-tracker.track-links', 1);
 
-        $old_email = MailTracker::newSentEmailModel()->newQuery()->create([
+        $old_email = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
-        $old_url = MailTracker::newSentEmailUrlClickedModel()->newQuery()->create([
+        $old_url = MailTracker::sentEmailUrlClickedModel()->newQuery()->create([
                 'sent_email_id' => $old_email->id,
                 'hash' => Str::random(32),
             ]);
@@ -128,7 +128,7 @@ class MailTrackerTest extends SetUpTest
                 'opened_at' => null,
                 'clicked_at' => null,
             ]);
-        $sent_email = MailTracker::newSentEmailModel()->newQuery()->where([
+        $sent_email = MailTracker::sentEmailModel()->newQuery()->where([
             'hash' => 'random-hash',
         ])->first();
         $this->assertEquals($name.' <'.$email.'>', $sent_email->recipient);
@@ -339,7 +339,7 @@ class MailTrackerTest extends SetUpTest
         Carbon::setTestNow(now());
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $pings = $track->opens;
@@ -368,7 +368,7 @@ class MailTrackerTest extends SetUpTest
         Carbon::setTestNow(now());
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
                 'opened_at' => now()->subDays(10),
             ]);
@@ -395,7 +395,7 @@ class MailTrackerTest extends SetUpTest
         Carbon::setTestNow(now());
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $clicks = $track->clicks;
@@ -426,7 +426,7 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail-tracker.inject-pixel', true);
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $redirect = 'http://'.Str::random(15).'.com/'.Str::random(10).'/'.Str::random(10).'/'.rand(0, 100).'/'.rand(0, 100).'?page='.rand(0, 100).'&x='.Str::random(32);
@@ -456,7 +456,7 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_redirects_even_if_no_sent_email_exists()
     {
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
 
@@ -519,7 +519,7 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_retrieves_the_mesage_id_from_laravel_mailer()
     {
-        $sent = MailTracker::newSentEmailModel()->newQuery()->create([
+        $sent = MailTracker::sentEmailModel()->newQuery()->create([
             'hash'=>'the-hash',
             'message_id'=>'to-be-replaced',
         ]);
@@ -576,7 +576,7 @@ class MailTrackerTest extends SetUpTest
     {
         Config::set('mail.default', 'ses');
         Config::set('mail.driver', null);
-        $sent = MailTracker::newSentEmailModel()->newQuery()->create([
+        $sent = MailTracker::sentEmailModel()->newQuery()->create([
             'hash'=>'the-hash',
             'message_id'=>'to-be-replaced',
         ]);
@@ -638,7 +638,7 @@ class MailTrackerTest extends SetUpTest
             ->andReturn('random-hash');
         Config::set('mail.driver', 'ses');
         Config::set('mail.default', null);
-        $sent = MailTracker::newSentEmailModel()->newQuery()->create([
+        $sent = MailTracker::sentEmailModel()->newQuery()->create([
             'hash'=>'the-hash',
             'message_id'=>'to-be-replaced',
         ]);
@@ -922,7 +922,7 @@ class MailTrackerTest extends SetUpTest
             'clicks' => 1,
         ]);
 
-        $track = MailTracker::newSentEmailModel()->newQuery()->whereHash($hash)->first();
+        $track = MailTracker::sentEmailModel()->newQuery()->whereHash($hash)->first();
         $this->assertNotNull($track);
         $this->assertEquals(1, $track->clicks);
     }
@@ -980,7 +980,7 @@ class MailTrackerTest extends SetUpTest
             'clicks' => 1,
         ]);
 
-        $track = MailTracker::newSentEmailModel()->newQuery()->whereHash($hash)->first();
+        $track = MailTracker::sentEmailModel()->newQuery()->whereHash($hash)->first();
         $this->assertNotNull($track);
         $this->assertEquals(1, $track->clicks);
     }
@@ -1018,7 +1018,7 @@ class MailTrackerTest extends SetUpTest
         } catch (TransportException $e) {
         }
 
-        $track = MailTracker::newSentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
+        $track = MailTracker::sentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
         $this->assertEquals($header_test, $track->getHeader('X-Header-Test'));
     }
 
@@ -1054,7 +1054,7 @@ class MailTrackerTest extends SetUpTest
         } catch (TransportException $e) {
         }
 
-        $track = MailTracker::newSentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
+        $track = MailTracker::sentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
         $this->assertEquals($header_test, $track->getHeader('X-Header-Test'));
     }
 
@@ -1095,7 +1095,7 @@ class MailTrackerTest extends SetUpTest
         } catch (TransportException $e) {
         }
 
-        $track = MailTracker::newSentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
+        $track = MailTracker::sentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
 
         $this->assertEquals(
             'CC This Person With a Long Name 1 <cc.averylongemail1@johndoe.com>, ' .
@@ -1123,10 +1123,10 @@ class MailTrackerTest extends SetUpTest
         $this->app['migrator']->setConnection('secondary');
         $this->artisan('migrate', ['--database' => 'secondary']);
 
-        $old_email = MailTracker::newSentEmailModel()->newQuery()->create([
+        $old_email = MailTracker::sentEmailModel()->newQuery()->create([
             'hash' => Str::random(32),
         ]);
-        $old_url = MailTracker::newSentEmailUrlClickedModel()->newQuery()->create([
+        $old_url = MailTracker::sentEmailUrlClickedModel()->newQuery()->create([
             'sent_email_id' => $old_email->id,
             'hash' => Str::random(32),
         ]);
@@ -1180,14 +1180,14 @@ class MailTrackerTest extends SetUpTest
     public function it_can_retrieve_url_clicks_from_eloquent()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
             'hash' => Str::random(32),
         ]);
         $message_id = Str::random(32);
         $track->message_id = $message_id;
         $track->save();
 
-        $urlClick = MailTracker::newSentEmailUrlClickedModel()->newQuery()->create([
+        $urlClick = MailTracker::sentEmailUrlClickedModel()->newQuery()->create([
             'sent_email_id' => $track->id,
             'url' => 'https://example.com',
             'hash' => Str::random(32)
@@ -1204,7 +1204,7 @@ class MailTrackerTest extends SetUpTest
     public function it_handles_headers_with_colons()
     {
         $headerData = '{"some_id":2,"some_othger_id":"0dd75231-31bb-4e67-8ab7-a83315f75a44","some_field":"A Field Value"}';
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
             'hash' => Str::random(32),
             'headers' => 'X-MyHeader: '.$headerData,
         ]);
@@ -1255,7 +1255,7 @@ class MailTrackerTest extends SetUpTest
             'content' => null
         ]);
 
-        $tracker = MailTracker::newSentEmailModel()->newQuery()->where('hash', '=','random-hash')->first();
+        $tracker = MailTracker::sentEmailModel()->newQuery()->where('hash', '=','random-hash')->first();
         $this->assertNotNull($tracker);
         $this->assertEquals($content, $tracker->content);
         $folder = config('mail-tracker.tracker-filesystem-folder', 'mail-tracker');

--- a/tests/MigrateRecipientsTest.php
+++ b/tests/MigrateRecipientsTest.php
@@ -19,7 +19,7 @@ class MigrateRecipientsTest extends SetUpTest
             $table->string('recipient')->nullable();
         });
         MailTracker::newSentEmailModel()::unguard();
-        $tracker = MailTracker::newSentEmailModel()->create([
+        $tracker = MailTracker::newSentEmailModel()->newQuery()->create([
             'hash' => 'email-hash',
             'sender' => 'Sender Dude <sender@example.com>',
             'recipient' => 'Recipient Dude <recipient@example.com>',
@@ -47,7 +47,7 @@ class MigrateRecipientsTest extends SetUpTest
             $table->string('recipient')->nullable();
         });
         MailTracker::newSentEmailModel()::unguard();
-        $tracker = MailTracker::newSentEmailModel()->create([
+        $tracker = MailTracker::newSentEmailModel()->newQuery()->create([
             'hash' => 'email-hash',
             'sender' => ' <sender@example.com>',
             'recipient' => ' <recipient@example.com>',

--- a/tests/MigrateRecipientsTest.php
+++ b/tests/MigrateRecipientsTest.php
@@ -14,12 +14,12 @@ class MigrateRecipientsTest extends SetUpTest
      */
     public function it_converts_existing_recipient_values()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->string('sender')->nullable();
             $table->string('recipient')->nullable();
         });
-        MailTracker::newSentEmailModel()::unguard();
-        $tracker = MailTracker::newSentEmailModel()->newQuery()->create([
+        MailTracker::sentEmailModel()::unguard();
+        $tracker = MailTracker::sentEmailModel()->newQuery()->create([
             'hash' => 'email-hash',
             'sender' => 'Sender Dude <sender@example.com>',
             'recipient' => 'Recipient Dude <recipient@example.com>',
@@ -42,12 +42,12 @@ class MigrateRecipientsTest extends SetUpTest
      */
     public function it_converts_existing_recipient_values_with_no_name()
     {
-        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::sentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->string('sender')->nullable();
             $table->string('recipient')->nullable();
         });
-        MailTracker::newSentEmailModel()::unguard();
-        $tracker = MailTracker::newSentEmailModel()->newQuery()->create([
+        MailTracker::sentEmailModel()::unguard();
+        $tracker = MailTracker::sentEmailModel()->newQuery()->create([
             'hash' => 'email-hash',
             'sender' => ' <sender@example.com>',
             'recipient' => ' <recipient@example.com>',

--- a/tests/MigrateRecipientsTest.php
+++ b/tests/MigrateRecipientsTest.php
@@ -5,7 +5,7 @@ namespace jdavidbakr\MailTracker\Tests;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use jdavidbakr\MailTracker\Console\MigrateRecipients;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use jdavidbakr\MailTracker\MailTracker;
 
 class MigrateRecipientsTest extends SetUpTest
 {
@@ -14,12 +14,12 @@ class MigrateRecipientsTest extends SetUpTest
      */
     public function it_converts_existing_recipient_values()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->string('sender')->nullable();
             $table->string('recipient')->nullable();
         });
-        SentEmail::unguard();
-        $tracker = SentEmail::create([
+        MailTracker::newSentEmailModel()::unguard();
+        $tracker = MailTracker::newSentEmailModel()->create([
             'hash' => 'email-hash',
             'sender' => 'Sender Dude <sender@example.com>',
             'recipient' => 'Recipient Dude <recipient@example.com>',
@@ -42,12 +42,12 @@ class MigrateRecipientsTest extends SetUpTest
      */
     public function it_converts_existing_recipient_values_with_no_name()
     {
-        Schema::connection((new SentEmail())->getConnectionName())->table('sent_emails', function (Blueprint $table) {
+        Schema::connection(MailTracker::newSentEmailModel()->getConnectionName())->table('sent_emails', function (Blueprint $table) {
             $table->string('sender')->nullable();
             $table->string('recipient')->nullable();
         });
-        SentEmail::unguard();
-        $tracker = SentEmail::create([
+        MailTracker::newSentEmailModel()::unguard();
+        $tracker = MailTracker::newSentEmailModel()->create([
             'hash' => 'email-hash',
             'sender' => ' <sender@example.com>',
             'recipient' => ' <recipient@example.com>',

--- a/tests/RecordBounceJobTest.php
+++ b/tests/RecordBounceJobTest.php
@@ -17,7 +17,7 @@ class RecordBounceJobTest extends SetUpTest
     public function it_handles_permanent_bounce()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();
@@ -61,7 +61,7 @@ class RecordBounceJobTest extends SetUpTest
     public function it_handles_transient_bounce()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();
@@ -110,7 +110,7 @@ class RecordBounceJobTest extends SetUpTest
     public function it_handles_transient_bounce_without_diagnostic_code()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();

--- a/tests/RecordBounceJobTest.php
+++ b/tests/RecordBounceJobTest.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use jdavidbakr\MailTracker\Events\PermanentBouncedMessageEvent;
 use jdavidbakr\MailTracker\Events\TransientBouncedMessageEvent;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\RecordBounceJob;
 
 class RecordBounceJobTest extends SetUpTest
@@ -17,7 +16,7 @@ class RecordBounceJobTest extends SetUpTest
     public function it_handles_permanent_bounce()
     {
         Event::fake();
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();
@@ -61,7 +60,7 @@ class RecordBounceJobTest extends SetUpTest
     public function it_handles_transient_bounce()
     {
         Event::fake();
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();
@@ -110,7 +109,7 @@ class RecordBounceJobTest extends SetUpTest
     public function it_handles_transient_bounce_without_diagnostic_code()
     {
         Event::fake();
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();

--- a/tests/RecordBounceJobTest.php
+++ b/tests/RecordBounceJobTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
 use jdavidbakr\MailTracker\Events\PermanentBouncedMessageEvent;
 use jdavidbakr\MailTracker\Events\TransientBouncedMessageEvent;
+use jdavidbakr\MailTracker\MailTracker;
 use jdavidbakr\MailTracker\RecordBounceJob;
 
 class RecordBounceJobTest extends SetUpTest
@@ -16,7 +17,7 @@ class RecordBounceJobTest extends SetUpTest
     public function it_handles_permanent_bounce()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();
@@ -60,7 +61,7 @@ class RecordBounceJobTest extends SetUpTest
     public function it_handles_transient_bounce()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();
@@ -109,7 +110,7 @@ class RecordBounceJobTest extends SetUpTest
     public function it_handles_transient_bounce_without_diagnostic_code()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();

--- a/tests/RecordComplaintJobTest.php
+++ b/tests/RecordComplaintJobTest.php
@@ -4,7 +4,6 @@ namespace jdavidbakr\MailTracker\Tests;
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Event;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\RecordBounceJob;
 use jdavidbakr\MailTracker\RecordComplaintJob;
 use jdavidbakr\MailTracker\Events\ComplaintMessageEvent;
@@ -17,7 +16,7 @@ class RecordComplaintJobTest extends SetUpTest
     public function it_marks_the_email_as_unsuccessful()
     {
         Event::fake();
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();

--- a/tests/RecordComplaintJobTest.php
+++ b/tests/RecordComplaintJobTest.php
@@ -17,7 +17,7 @@ class RecordComplaintJobTest extends SetUpTest
     public function it_marks_the_email_as_unsuccessful()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();

--- a/tests/RecordComplaintJobTest.php
+++ b/tests/RecordComplaintJobTest.php
@@ -4,6 +4,7 @@ namespace jdavidbakr\MailTracker\Tests;
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Event;
+use jdavidbakr\MailTracker\MailTracker;
 use jdavidbakr\MailTracker\RecordBounceJob;
 use jdavidbakr\MailTracker\RecordComplaintJob;
 use jdavidbakr\MailTracker\Events\ComplaintMessageEvent;
@@ -16,7 +17,7 @@ class RecordComplaintJobTest extends SetUpTest
     public function it_marks_the_email_as_unsuccessful()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();

--- a/tests/RecordDeliveryJobTest.php
+++ b/tests/RecordDeliveryJobTest.php
@@ -19,7 +19,7 @@ class RecordDeliveryJobTest extends SetUpTest
     public function it_marks_the_email_as_unsuccessful()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();

--- a/tests/RecordDeliveryJobTest.php
+++ b/tests/RecordDeliveryJobTest.php
@@ -4,6 +4,7 @@ namespace jdavidbakr\MailTracker\Tests;
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Event;
+use jdavidbakr\MailTracker\MailTracker;
 use jdavidbakr\MailTracker\RecordBounceJob;
 use jdavidbakr\MailTracker\RecordDeliveryJob;
 use jdavidbakr\MailTracker\RecordComplaintJob;
@@ -18,7 +19,7 @@ class RecordDeliveryJobTest extends SetUpTest
     public function it_marks_the_email_as_unsuccessful()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();

--- a/tests/RecordDeliveryJobTest.php
+++ b/tests/RecordDeliveryJobTest.php
@@ -4,7 +4,6 @@ namespace jdavidbakr\MailTracker\Tests;
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Event;
-use jdavidbakr\MailTracker\Model\SentEmail;
 use jdavidbakr\MailTracker\RecordBounceJob;
 use jdavidbakr\MailTracker\RecordDeliveryJob;
 use jdavidbakr\MailTracker\RecordComplaintJob;
@@ -19,7 +18,7 @@ class RecordDeliveryJobTest extends SetUpTest
     public function it_marks_the_email_as_unsuccessful()
     {
         Event::fake();
-        $track = SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->create([
                 'hash' => Str::random(32),
             ]);
         $message_id = Str::uuid();

--- a/tests/RecordLinkClickJobTest.php
+++ b/tests/RecordLinkClickJobTest.php
@@ -4,7 +4,7 @@ namespace jdavidbakr\MailTracker\Tests;
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Event;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use jdavidbakr\MailTracker\MailTracker;
 use jdavidbakr\MailTracker\RecordBounceJob;
 use jdavidbakr\MailTracker\RecordDeliveryJob;
 use jdavidbakr\MailTracker\RecordComplaintJob;
@@ -19,7 +19,7 @@ class RecordLinkClickJobTest extends SetUpTest
     public function it_records_clicks_to_links()
     {
         Event::fake();
-        $track = \jdavidbakr\MailTracker\Model\SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $clicks = $track->clicks;

--- a/tests/RecordLinkClickJobTest.php
+++ b/tests/RecordLinkClickJobTest.php
@@ -19,7 +19,7 @@ class RecordLinkClickJobTest extends SetUpTest
     public function it_records_clicks_to_links()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $clicks = $track->clicks;

--- a/tests/RecordTrackingJobTest.php
+++ b/tests/RecordTrackingJobTest.php
@@ -4,7 +4,7 @@ namespace jdavidbakr\MailTracker\Tests;
 
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Event;
-use jdavidbakr\MailTracker\Model\SentEmail;
+use jdavidbakr\MailTracker\MailTracker;
 use jdavidbakr\MailTracker\RecordBounceJob;
 use jdavidbakr\MailTracker\RecordDeliveryJob;
 use jdavidbakr\MailTracker\RecordTrackingJob;
@@ -21,11 +21,11 @@ class RecordTrackingJobTest extends SetUpTest
     public function it_records_views()
     {
         Event::fake();
-        $track = \jdavidbakr\MailTracker\Model\SentEmail::create([
+        $track = MailTracker::newSentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $job = new RecordTrackingJob($track, '127.0.0.1');
-        
+
         $job->handle();
 
         Event::assertDispatched(ViewEmailEvent::class, function ($e) use ($track) {

--- a/tests/RecordTrackingJobTest.php
+++ b/tests/RecordTrackingJobTest.php
@@ -21,7 +21,7 @@ class RecordTrackingJobTest extends SetUpTest
     public function it_records_views()
     {
         Event::fake();
-        $track = MailTracker::newSentEmailModel()->newQuery()->create([
+        $track = MailTracker::sentEmailModel()->newQuery()->create([
                 'hash' => Str::random(32),
             ]);
         $job = new RecordTrackingJob($track, '127.0.0.1');


### PR DESCRIPTION
This MR enables to override the used models: `SentEmail` and `SentEmailUrlClicked`.

It adds static properties to the MailTracker class, which holds the classes of the models. Here is how it works:

```php
// overriding models
MailTracker::useSentEmailModel(OwnSentEmail::class);
MailTracker::useSentEmailUrlClickedModel(OwnSentEmailUrlClicked::class);

// creating models
$sentEmail = MailTracker::sentEmailModel();
$sentEmailUrlClicked = MailTracker::sentEmailUrlClickedModel();

// accessing classes
MailTracker::$sentEmailModel
MailTracker::$sentEmailUrlClickedModel
```

This pattern is well known across the Laravel ecosystem like in Laravel Passport (Passport::useTokenModel).


I updated the readme and added tests for this.