### PR TITLE
Delete files during deletion of SentEmail

### DIFF
--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -46,6 +46,16 @@ class SentEmail extends Model
         'clicked_at' => 'datetime',
     ];
 
+    protected static function boot()
+    {
+        parent::boot();
+        static::deleting(function ($email) {
+            if ($email->meta && ($filePath = $email->meta->get('content_file_path'))) {
+                Storage::disk(config('mail-tracker.tracker-filesystem'))->delete($filePath);
+            }
+        });
+    }
+
     public function getConnectionName()
     {
         $connName = config('mail-tracker.connection');

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -46,11 +46,10 @@ class SentEmail extends Model
         'clicked_at' => 'datetime',
     ];
 
-    protected static function boot()
+    protected static function booted()
     {
-        parent::boot();
-        static::deleting(function ($email) {
-            if ($email->meta && ($filePath = $email->meta->get('content_file_path'))) {
+        static::deleting(function (self $email) {
+            if ($filePath = $email->meta?->get('content_file_path')) {
                 Storage::disk(config('mail-tracker.tracker-filesystem'))->delete($filePath);
             }
         });


### PR DESCRIPTION
With #211 there is a new strategy to save the content of emails. It stores the content into the filesystem but never deletes the file.

This MR fixes this by registering a hook during the `deletion` event of the model and deleting the file if it exists.