### PR TITLE
Fix security issue

### DIFF
--- a/src/MailTrackerController.php
+++ b/src/MailTrackerController.php
@@ -64,7 +64,7 @@ class MailTrackerController extends Controller
             $url = config('mail-tracker.redirect-missing-links-to') ?: '/';
         }
         $tracker = MailTracker::sentEmailModel()->newQuery()->where('hash', $hash)
-            ->first();
+            ->firstOrFail();
         if ($tracker) {
             RecordLinkClickJob::dispatch($tracker, $url, request()->ip())
                 ->onQueue(config('mail-tracker.tracker-queue'));


### PR DESCRIPTION
Redirect to link is working even if email model hash was missing in url query. 
You can generate links that redirect to other pages. Because of this error, my website was used for phishing campaigns.

Example of prepared url: https://example.com/email/n?l=https://google.com

This PR is fixing  this by ensuring, that model hash exists and is valid.