### PR TITLE
Handle exceptions better

### DIFF
--- a/src/RecordBounceJob.php
+++ b/src/RecordBounceJob.php
@@ -20,6 +20,13 @@ class RecordBounceJob implements ShouldQueue
 
     public $message;
 
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
+
     public function __construct($message)
     {
         $this->message = $message;

--- a/src/RecordComplaintJob.php
+++ b/src/RecordComplaintJob.php
@@ -19,6 +19,13 @@ class RecordComplaintJob implements ShouldQueue
 
     public $message;
 
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
+
     public function __construct($message)
     {
         $this->message = $message;

--- a/src/RecordDeliveryJob.php
+++ b/src/RecordDeliveryJob.php
@@ -19,6 +19,13 @@ class RecordDeliveryJob implements ShouldQueue
 
     public $message;
 
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
+
     public function __construct($message)
     {
         $this->message = $message;

--- a/src/RecordLinkClickJob.php
+++ b/src/RecordLinkClickJob.php
@@ -21,6 +21,13 @@ class RecordLinkClickJob implements ShouldQueue
     public $url;
     public $ipAddress;
 
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
+
     public function retryUntil()
     {
         return now()->addDays(5);

--- a/src/RecordTrackingJob.php
+++ b/src/RecordTrackingJob.php
@@ -20,6 +20,13 @@ class RecordTrackingJob implements ShouldQueue
     public $sentEmail;
     public $ipAddress;
 
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 3;
+
     public function __construct($sentEmail, $ipAddress)
     {
         $this->sentEmail = $sentEmail;


### PR DESCRIPTION
So i have an issue where a really long link is triggering a DB exception. Which is causing the job to fail, which then retries as we have retryUntil for 5 days! Should this be 5 minutes instead? 5 days seems like alot, so i'm introducing max exceptions. My current issue is the Sent Email entry clicks is being incremented each timeit fails but it can't create the SentEmailUrlClicked entry so retries the job. Sent Email entry was at 20000 clicks before i saw it. 

A diff solution would be to change the retryUntil to be shorter. Not sure what the use case was for that to be introduced

```
public function retryUntil()
    {
        return now()->addDays(5);
    }
```