### PR TITLE
Add date filtering to search

### DIFF
--- a/config/mail-tracker.php
+++ b/config/mail-tracker.php
@@ -99,4 +99,9 @@ return [
      * Size limit for content length stored in database
      */
     'content-max-size' => 65535,
+
+    /**
+     * Length of time to default past email search - if set, will set the default past limit to the amount of days below (Ex: => 356)
+     */
+    'search-date-start' => null,
 ];

--- a/src/views/index.blade.php
+++ b/src/views/index.blade.php
@@ -15,21 +15,43 @@
         </div>
         <div class="row">
             <div class="col-sm-12 text-center">
-                <form action="{{ route('mailTracker_Search') }}" method="post" class="form-inline">
+                <form action="{{ route('mailTracker_Search') }}" method="post">
                     {!! csrf_field() !!}
-                    <div class="form-group">
-                        <label for="search">
-                            Search
-                        </label>
-                        <input type="text" name="search" id="search" value="{{ session('mail-tracker-index-search') }}">
+                    <div class="col-sm-{{ !is_null(config('mail-tracker.search-date-start')) ? '3' : '4' }}">
+                        <div class="form-group">
+                            <label for="search" class="form-label">
+                                Search
+                            </label>
+                            <input type="text" class="form-control" name="search" id="search" value="{{ session('mail-tracker-index-search') }}">
+                        </div>
                     </div>
-                    <button type="submit" class="btn btn-default">
-                        Search
-                    </button>
-                    <div class="btn btn-default">
-                        <a href="{{ route('mailTracker_ClearSearch') }}">
-                            Clear Search
-                        </a>
+                    @if( !is_null(config('mail-tracker.search-date-start')) )
+                        <div class="col-sm-3">
+                            <div class="form-group">
+                                <label for="date_start" class="form-label">
+                                    Sent at - beginning
+                                </label>
+                                <input type="date" class="form-control" name="date_start" id="date_start" value="{{ session('mail-tracker-index-date-start') }}">
+                            </div>
+                        </div>
+                        <div class="col-sm-3">
+                            <div class="form-group">
+                                <label for="date_end" class="form-label">
+                                    Sent at - end
+                                </label>
+                                <input type="date" class="form-control" name="date_end" id="date_end" value="{{ session('mail-tracker-index-date-end') }}">
+                            </div>
+                        </div>
+                    @endif
+                    <div class="col-sm-{{ !is_null(config('mail-tracker.search-date-start')) ? '3' : '8' }}">
+                        <button type="submit" class="btn btn-default">
+                            Search
+                        </button>
+                        <div class="btn btn-default">
+                            <a href="{{ route('mailTracker_ClearSearch') }}">
+                                Clear Search
+                            </a>
+                        </div>
                     </div>
                 </form>
                 <hr>


### PR DESCRIPTION
After prolonged use of the tool, my organization (and possibly many others) has encountered an issue. We can't archive our `sent_emails` yet, but we still want great performance. Therefore, we have introduced a date-filtering option to the search functionality.