### PR TITLE
avoid 404 error if email tracker has been deleted

### DIFF
--- a/src/MailTrackerController.php
+++ b/src/MailTrackerController.php
@@ -64,7 +64,7 @@ class MailTrackerController extends Controller
             $url = config('mail-tracker.redirect-missing-links-to') ?: '/';
         }
         $tracker = MailTracker::sentEmailModel()->newQuery()->where('hash', $hash)
-            ->firstOrFail();
+            ->first();
         if ($tracker) {
             RecordLinkClickJob::dispatch($tracker, $url, request()->ip())
                 ->onQueue(config('mail-tracker.tracker-queue'));


### PR DESCRIPTION
This PR solves this issue that currently happens when an email tracker has been deleted and users get a 404 error when they click on links in their emails.