### PR TITLE
Add dont track option

### DIFF
--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -250,12 +250,12 @@ class MailTracker
                 $from_email = $fromAddress->getAddress();
                 $from_name = $fromAddress->getName();
                 $headers = $message->getHeaders();
+
+                // Don't track this email
                 if ($headers->get('X-No-Track')) {
-                    // Don't send with this header
-                    $headers->remove('X-No-Track');
-                    // Don't track this email
                     continue;
                 }
+
                 do {
                     $hash = app(Str::class)->random(32);
                     $used = MailTracker::sentEmailModel()->newQuery()->where('hash', $hash)->count();
@@ -336,6 +336,9 @@ class MailTracker
                 Event::dispatch(new EmailSentEvent($tracker));
             }
         }
+
+        // Remove this header if it was set
+        $message->getHeaders()->remove('X-No-Track');
     }
 
     /**

--- a/tests/MailTrackerTest.php
+++ b/tests/MailTrackerTest.php
@@ -298,15 +298,17 @@ class MailTrackerTest extends SetUpTest
     {
         $faker = Factory::create();
         $email = $faker->email;
+        $anotherEmail = $faker->email;
         $subject = $faker->sentence;
         $name = $faker->firstName . ' ' .$faker->lastName;
         View::addLocation(__DIR__);
         try {
-            Mail::send('email.test', [], function ($message) use ($email, $subject, $name) {
+            Mail::send('email.test', [], function ($message) use ($email, $anotherEmail, $subject, $name) {
                 $message->from('from@johndoe.com', 'From Name');
                 $message->sender('sender@johndoe.com', 'Sender Name');
 
                 $message->to($email, $name);
+                $message->to($anotherEmail, $name);
 
                 $message->cc('cc@johndoe.com', 'CC Name');
                 $message->bcc('bcc@johndoe.com', 'BCC Name');
@@ -323,13 +325,20 @@ class MailTrackerTest extends SetUpTest
         }
 
         $this->assertDatabaseMissing('sent_emails', [
-                'recipient' => $name.' <'.$email.'>',
-                'subject' => $subject,
-                'sender_name' => 'From Name',
-                'sender_email' => 'from@johndoe.com',
-                'recipient_name' => $name,
-                'recipient_email' => $email,
-            ]);
+            'subject' => $subject,
+            'sender_name' => 'From Name',
+            'sender_email' => 'from@johndoe.com',
+            'recipient_name' => $name,
+            'recipient_email' => $email,
+        ]);
+
+        $this->assertDatabaseMissing('sent_emails', [
+            'subject' => $subject,
+            'sender_name' => 'From Name',
+            'sender_email' => 'from@johndoe.com',
+            'recipient_name' => $name,
+            'recipient_email' => $anotherEmail,
+        ]);
     }
 
     /**


### PR DESCRIPTION
#238 

Hey there. So turns out the test had a bug in it too, which i've now resolved. I commented out the No-Track and the test still passed due to the 'recipient' value being in the list of attributes

@jdavidbakr 