### PR TITLE
Add Ability to Skip Tracking based on an event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,39 @@ class OwnEmailSentModel extends Model implements SentEmailModel {
 }
 ```
 
+## Skip Tracking for Specific Emails
+
+If you have a specific email that you do not want to track, you can add the `X-No-Track` header to the email. This will prevent the email from being tracked. The header will be removed from the email prior to being sent.
+
+In laravel 9 onwards you can introduce a headers method to your Mailable class. This will stop the tracking pixel/click tracking from applying to the Mailable
+```php
+public function headers()
+{
+    return [
+        'X-No-Track' => Str::random(10),
+    ];
+}
+```
+
+## Skipping Open/Click Tracking for Anti-virus/Spam Filters
+
+Some mail servers might scan emails before they deliver which can trigger the tracking pixel, or even clicked links. You can add an event listener to the ValidActionEvent to handle this. 
+
+```php
+class ValidUserListener {
+    public function handle(ValidActionEvent $event)
+    {
+        if (in_array(request()->userAgent(), ['Mozilla/5.0', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246 Mozilla/5.0']) {
+            $event->skip = true;
+        }
+    }
+}
+```
+
+Ensure you add the listener to the `ValidActionEvent` in your `EventServiceProvider`, if you aren't using automatic event discovery.
+
+```php
+
 ## Note on dev testing
 
 Several people have reported the tracking pixel not working while they were testing. What is happening with the tracking pixel is that the email client is connecting to your website to log the view. In order for this to happen, images have to be visible in the client, and the client has to be able to connect to your server.

--- a/src/Events/ValidActionEvent.php
+++ b/src/Events/ValidActionEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
+
+class ValidActionEvent
+{
+    use Dispatchable;
+
+    public $skip = false;
+
+    public function __construct(Model|SentEmailModel $sent_email)
+    {
+        $this->sent_email = $sent_email;
+    }
+}

--- a/tests/MailTrackerControllerTest.php
+++ b/tests/MailTrackerControllerTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Tests;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
+use jdavidbakr\MailTracker\Events\ValidActionEvent;
+use jdavidbakr\MailTracker\MailTracker;
+
+class SkipListener
+{
+    public function handle(ValidActionEvent $event)
+    {
+        $event->skip = true;
+    }
+}
+
+class ContinueListener
+{
+    public function handle(ValidActionEvent $event)
+    {
+        $event->skip = false;
+    }
+}
+
+class MailTrackerControllerTest extends SetUpTest
+{
+    public function testReadTrackingIsSkipped()
+    {
+        Event::listen(
+            ValidActionEvent::class,
+            SkipListener::class,
+        );
+
+        // Create an old email to purge
+        Config::set('mail-tracker.inject-pixel', 1);
+        Config::set('mail-tracker.track-links', 1);
+
+        $email = MailTracker::sentEmailModel()->newQuery()->create([
+            'hash' => Str::random(32),
+        ]);
+
+        $this->get(route('mailTracker_t', [$email->hash]));
+
+        $email->refresh();
+
+        $this->assertNull($email->opened_at);
+    }
+
+    public function testReadTrackingIsNotSkipped()
+    {
+        Event::listen(
+            ValidActionEvent::class,
+            ContinueListener::class,
+        );
+
+        // Create an old email to purge
+        Config::set('mail-tracker.inject-pixel', 1);
+        Config::set('mail-tracker.track-links', 1);
+
+        $email = MailTracker::sentEmailModel()->newQuery()->create([
+            'hash' => Str::random(32),
+        ]);
+
+        $this->get(route('mailTracker_t', [$email->hash]));
+
+        $email->refresh();
+
+        $this->assertNotNull($email->opened_at);
+    }
+
+    public function testLinkTrackingIsSkipped()
+    {
+        Event::listen(
+            ValidActionEvent::class,
+            SkipListener::class,
+        );
+
+        // Create an old email to purge
+        Config::set('mail-tracker.inject-pixel', 1);
+        Config::set('mail-tracker.track-links', 1);
+
+        $email = MailTracker::sentEmailModel()->newQuery()->create([
+            'hash' => Str::random(32),
+        ]);
+
+        $redirect = 'http://' . Str::random(15) . '.com/' . Str::random(10) . '/' . Str::random(10) . '/' . rand(0, 100) . '/' . rand(0, 100) . '?page=' . rand(0, 100) . '&x=' . Str::random(32);
+
+        $this->get(route('mailTracker_l', [
+            MailTracker::hash_url($redirect), // Replace slash with dollar sign
+            $email->hash,
+        ]));
+
+        $email->refresh();
+
+        $this->assertNull($email->opened_at);
+        $this->assertNull($email->clicked_at);
+    }
+
+    public function testLinkTrackingIsNotSkipped()
+    {
+        Event::listen(
+            ValidActionEvent::class,
+            ContinueListener::class,
+        );
+
+        // Create an old email to purge
+        Config::set('mail-tracker.inject-pixel', 1);
+        Config::set('mail-tracker.track-links', 1);
+
+        $email = MailTracker::sentEmailModel()->newQuery()->create([
+            'hash' => Str::random(32),
+        ]);
+
+        $redirect = 'http://' . Str::random(15) . '.com/' . Str::random(10) . '/' . Str::random(10) . '/' . rand(0, 100) . '/' . rand(0, 100) . '?page=' . rand(0, 100) . '&x=' . Str::random(32);
+
+        $this->get(route('mailTracker_l', [
+            MailTracker::hash_url($redirect), // Replace slash with dollar sign
+            $email->hash,
+        ]));
+
+        $email->refresh();
+
+        $this->assertNotNull($email->opened_at);
+        $this->assertNotNull($email->clicked_at);
+    }
+}


### PR DESCRIPTION
#228 - Thought i'd help with this issue. Now someone could add an Event Listener that can check anything they want on the request to determine whether it's a spam checker or not. 

See the test for an example. The Listener just sets the $skip = true on the original event and it all works