### PR TITLE
Fixes SNS Endpoint Header check issue for Serverless Environments (Laravel Vapor)

### DIFF
--- a/src/SNSController.php
+++ b/src/SNSController.php
@@ -29,10 +29,10 @@ class SNSController extends Controller
             // get body from request
             $body = $request->getContent();
 
-            // Make sure the SNS-provided header exists.
-            /**if (!isset($_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE'])) {
+            $messageType = $request->header('x-amz-sns-message-type');
+            if (!$messageType) {
                 throw new \RuntimeException('SNS message type header not provided.');
-            }**/
+            }
 
             $message = SNSMessage::fromJsonString($body);
             $validator = app(SNSMessageValidator::class);

--- a/src/SNSController.php
+++ b/src/SNSController.php
@@ -30,9 +30,9 @@ class SNSController extends Controller
             $body = $request->getContent();
 
             // Make sure the SNS-provided header exists.
-            if (!isset($_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE'])) {
+            /**if (!isset($_SERVER['HTTP_X_AMZ_SNS_MESSAGE_TYPE'])) {
                 throw new \RuntimeException('SNS message type header not provided.');
-            }
+            }**/
 
             $message = SNSMessage::fromJsonString($body);
             $validator = app(SNSMessageValidator::class);

--- a/src/SNSController.php
+++ b/src/SNSController.php
@@ -29,6 +29,7 @@ class SNSController extends Controller
             // get body from request
             $body = $request->getContent();
 
+            // Make sure the SNS-provided header exists.
             $messageType = $request->header('x-amz-sns-message-type');
             if (!$messageType) {
                 throw new \RuntimeException('SNS message type header not provided.');


### PR DESCRIPTION
In serverless environments, such as Laravel Vapor, the direct access to $_SERVER global variable for retrieving request headers, such as HTTP_X_AMZ_SNS_MESSAGE_TYPE, is unreliable. This becomes a problem when handling Amazon Simple Notification Service (SNS) messages, as it's essential to validate the type of SNS message being processed. The Laravel way of accessing request headers through the Request object should be used instead to ensure compatibility across different environments, including serverless.

This pull request addresses this issue by replacing direct $_SERVER access with the Laravel Request object for fetching the x-amz-sns-message-type header. It ensures that the application remains environment-agnostic and functions correctly in both server-based and serverless deployments.