### PR TITLE
Fix issue #201

### DIFF
--- a/src/MailTrackerController.php
+++ b/src/MailTrackerController.php
@@ -65,8 +65,11 @@ class MailTrackerController extends Controller
         if (!$url) {
             $url = config('mail-tracker.redirect-missing-links-to') ?: '/';
         }
+
+        $url_host = parse_url($url, PHP_URL_HOST);
         $tracker = MailTracker::sentEmailModel()->newQuery()->where('hash', $hash)
             ->first();
+
         if ($tracker) {
             $event = new ValidActionEvent($tracker);
 
@@ -88,6 +91,11 @@ class MailTrackerController extends Controller
                 }
             }
         }
+
+        if ( ! $tracker || ! in_array($url_host, $tracker->domains_in_content) ){
+            return redirect(config('mail-tracker.redirect-missing-links-to') ?: '/');
+        }
+
         return redirect($url);
     }
 }

--- a/src/MailTrackerController.php
+++ b/src/MailTrackerController.php
@@ -92,7 +92,7 @@ class MailTrackerController extends Controller
             }
         }
 
-        if ( ! $tracker || ! in_array($url_host, $tracker->domains_in_content) ){
+        if ( ! $tracker || empty($tracker->domains_in_context) || ! in_array($url_host, $tracker->domains_in_context) ){
             return redirect(config('mail-tracker.redirect-missing-links-to') ?: '/');
         }
 

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -45,4 +45,22 @@ class SentEmail extends Model implements SentEmailModel
         'opened_at' => 'datetime',
         'clicked_at' => 'datetime',
     ];
+
+    protected $appends = [
+        'domains_in_content'
+    ];
+
+    public function getDomainsInContentAttribute(){
+        preg_match_all("/(<a[^>]*href=[\"])([^\"]*)/", $this->content, $matches);
+        if ( ! isset($matches[2]) ) return [];
+        $domains = [];
+        foreach($matches[2] as $url){
+            $domain = parse_url($url, PHP_URL_HOST);
+            if ( ! in_array($domain, $domains) ){
+                $domains[] = $domain;
+            }
+        }
+
+        return $domains;
+    }
 }

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -47,10 +47,10 @@ class SentEmail extends Model implements SentEmailModel
     ];
 
     protected $appends = [
-        'domains_in_content'
+        'domains_in_context'
     ];
 
-    public function getDomainsInContentAttribute(){
+    public function getDomainsInContextAttribute(){
         preg_match_all("/(<a[^>]*href=[\"])([^\"]*)/", $this->content, $matches);
         if ( ! isset($matches[2]) ) return [];
         $domains = [];


### PR DESCRIPTION
- Added `domains_in_content` to the SentEmail model: This field will store a list of domains that are allowed to be clicked on in emails. This will help to prevent users from clicking on malicious links.
- Implemented a second check in MailTrackerController: This check will make sure that the domain of the link where the user is trying to go is actually in the `domains_in_content` list. If it is not, then the user will be redirected to the `config('mail-tracker.redirect-missing-links-to')` URL.