### PR TITLE
Insert tracking pixel after <body> tag open.

### DIFF
--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -184,7 +184,7 @@ class MailTracker
         $html = str_replace("\n", $linebreak, $html);
 
         if (preg_match("/^(.*<body[^>]*>)(.*)$/", $html, $matches)) {
-            $html = $matches[1].$matches[2].$tracking_pixel;
+            $html = $matches[1].$tracking_pixel.$matches[2];
         } else {
             $html = $html . $tracking_pixel;
         }


### PR DESCRIPTION
It looks to me like we are aiming at putting the tracking pixel after the opening <body> tag but we end up actually sticking it on the end of the HTML. This fixes that.