### PR TITLE
fix proposal for issue with link and redirect when content is not saved

### DIFF
--- a/src/MailTrackerController.php
+++ b/src/MailTrackerController.php
@@ -92,6 +92,10 @@ class MailTrackerController extends Controller
             }
         }
 
+        if ($tracker && is_null($tracker->content)) {
+            return redirect($url);
+        }
+
         if ( ! $tracker || empty($tracker->domains_in_context) || ! in_array($url_host, $tracker->domains_in_context) ){
             return redirect(config('mail-tracker.redirect-missing-links-to') ?: '/');
         }


### PR DESCRIPTION
As discussed in the issue #254 here it is a simple proposal to fix the case when the content of the sent newsletter has not been saved in the db

 