### PR TITLE
sent_email property is not declared in ValidActionEvent class

### DIFF
--- a/src/Events/ValidActionEvent.php
+++ b/src/Events/ValidActionEvent.php
@@ -11,6 +11,7 @@ class ValidActionEvent
     use Dispatchable;
 
     public $skip = false;
+    public $sent_email;
 
     public function __construct(Model|SentEmailModel $sent_email)
     {


### PR DESCRIPTION
This PR declares the property `sent_email` in the `ValidActionEvent` class.