### PR TITLE
Fix Content-Length mismatch in tracking pixel response

### DIFF
--- a/src/MailTrackerController.php
+++ b/src/MailTrackerController.php
@@ -18,7 +18,7 @@ class MailTrackerController extends Controller
         $pixel = sprintf('%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c', 71, 73, 70, 56, 57, 97, 1, 0, 1, 0, 128, 255, 0, 192, 192, 192, 0, 0, 0, 33, 249, 4, 1, 0, 0, 0, 0, 44, 0, 0, 0, 0, 1, 0, 1, 0, 0, 2, 2, 68, 1, 0, 59);
         $response = Response::make($pixel, 200);
         $response->header('Content-type', 'image/gif');
-        $response->header('Content-Length', 42);
+        $response->header('Content-Length', strlen($pixel));
         $response->header('Cache-Control', 'private, no-cache, no-cache=Set-Cookie, proxy-revalidate');
         $response->header('Expires', 'Wed, 11 Jan 2000 12:59:00 GMT');
         $response->header('Last-Modified', 'Wed, 11 Jan 2006 12:59:00 GMT');


### PR DESCRIPTION
This PR fixes an issue where the Content-Length header in the getT method was hardcoded to 42, but the actual pixel content length could differ slightly depending on the environment or PHP version. This mismatch caused FastCGI warnings in production (upstream sent more data than specified in "Content-Length").

## Changes:

Set Content-Length dynamically using strlen($pixel) instead of a hardcoded value.

## Why:

Ensures the response headers always match the actual response body.

Prevents server warnings and potential delivery issues when serving the tracking pixel.

No functional changes to the pixel itself. Only fixes a header mismatch.

<img width="769" alt="Screenshot 2025-04-26 at 10 57 11 AM" src="https://github.com/user-attachments/assets/1d78a9b7-e726-46b6-88cc-315695beef6d" />