### PR TITLE
Introduce signed routes

### DIFF
--- a/config/mail-tracker.php
+++ b/config/mail-tracker.php
@@ -4,23 +4,23 @@ return [
     /**
      * To disable the pixel injection, set this to false.
      */
-    'inject-pixel' => true,
+    'inject-pixel'              => true,
 
     /**
      * To disable injecting tracking links, set this to false.
      */
-    'track-links' => true,
+    'track-links'               => true,
 
     /**
      * Optionally expire old emails, set to 0 to keep forever.
      */
-    'expire-days' => 60,
+    'expire-days'               => 60,
 
     /**
      * Where should the pingback URL route be?
      */
-    'route' => [
-        'prefix' => 'email',
+    'route'                     => [
+        'prefix'     => 'email',
         'middleware' => ['api'],
     ],
 
@@ -32,12 +32,12 @@ return [
     /**
      * Where should the admin route be?
      */
-    'admin-route' => [
-        'enabled' => true, // Should the admin routes be enabled?
-        'prefix' => 'email-manager',
+    'admin-route'               => [
+        'enabled'    => true, // Should the admin routes be enabled?
+        'prefix'     => 'email-manager',
         'middleware' => [
             'web',
-            'can:see-sent-emails'
+            'can:see-sent-emails',
         ],
     ],
 
@@ -48,60 +48,68 @@ return [
      * 'section' => 'content' for Default emailTraking use 'content'
      * 'styles_section' => 'styles' for Default emailTraking use 'styles'
      */
-    'admin-template' => [
-        'name' => 'emailTrakingViews::layouts.app',
+    'admin-template'            => [
+        'name'    => 'emailTrakingViews::layouts.app',
         'section' => 'content',
     ],
 
     /**
      * Number of emails per page in the admin view
      */
-    'emails-per-page' => 30,
+    'emails-per-page'           => 30,
 
     /**
      * Date Format
      */
-    'date-format' => 'm/d/Y g:i a',
+    'date-format'               => 'm/d/Y g:i a',
 
     /**
      * Default database connection name (optional - use null for default)
      */
-    'connection' => null,
+    'connection'                => null,
 
     /**
      * The SNS notification topic - if set, discard all notifications not in this topic.
      */
-    'sns-topic' => null,
+    'sns-topic'                 => null,
 
     /**
      * Determines whether the body of the email is logged in the sent_emails table
      */
-    'log-content' => true,
+    'log-content'               => true,
 
     /**
      * Determines whether the body should be stored in a file instead of database
      * Can be either 'database' or 'filesystem'
      */
-    'log-content-strategy' => 'database',
+    'log-content-strategy'      => 'database',
 
     /**
      * What filesystem we use for storing content html files
      */
-    'tracker-filesystem' => null,
+    'tracker-filesystem'        => null,
     'tracker-filesystem-folder' => 'mail-tracker',
 
     /**
      * What queue should we dispatch our tracking jobs to?  Null will use the default queue.
      */
-    'tracker-queue' => null,
+    'tracker-queue'             => null,
 
     /**
      * Size limit for content length stored in database
      */
-    'content-max-size' => 65535,
+    'content-max-size'          => 65535,
 
     /**
      * Length of time to default past email search - if set, will set the default past limit to the amount of days below (Ex: => 356)
      */
-    'search-date-start' => null,
+    'search-date-start'         => null,
+
+    /**
+     * Signed route enforcement settings - signed routes are now used to prevent redirect hijacking
+     */
+    'signed_route_enforcement'  => [
+        'start_date'        => env('MAIL_TRACKER_SIGNED_ROUTE_START_DATE', '2025-07-01'), // When the signed routes come into effect, after this date, all routes will be signed
+        'grace_period_days' => 30, // Default expiration time for signed routes in seconds (1 day)
+    ],
 ];

--- a/config/mail-tracker.php
+++ b/config/mail-tracker.php
@@ -106,10 +106,9 @@ return [
     'search-date-start'         => null,
 
     /**
-     * Signed route enforcement settings - signed routes are now used to prevent redirect hijacking
+     * Fallback method for when ValidateSignature has been introduced, but old links still need to be supported
      */
-    'signed_route_enforcement'  => [
-        'start_date'        => env('MAIL_TRACKER_SIGNED_ROUTE_START_DATE', '2025-07-01'), // When the signed routes come into effect, after this date, all routes will be signed
-        'grace_period_days' => 30, // Default expiration time for signed routes in seconds (1 day)
-    ],
+    'fallback-event-listeners' => [
+        \jdavidbakr\MailTracker\Listener\DomainExistsInContentListener::class,
+    ]
 ];

--- a/src/Events/ValidLinkEvent.php
+++ b/src/Events/ValidLinkEvent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Events;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Events\Dispatchable;
+use jdavidbakr\MailTracker\Contracts\SentEmailModel;
+
+class ValidLinkEvent
+{
+    use Dispatchable;
+
+    public $valid = false;
+    public $sent_email;
+    public $url;
+
+    public function __construct(Model|SentEmailModel $sent_email, $url)
+    {
+        $this->sent_email = $sent_email;
+        $this->url        = $url;
+    }
+}

--- a/src/Listener/DomainExistsInContentListener.php
+++ b/src/Listener/DomainExistsInContentListener.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Listener;
+
+use jdavidbakr\MailTracker\Events\ValidLinkEvent;
+
+class DomainExistsInContentListener
+{
+    public function handle(ValidLinkEvent $event): void
+    {
+        $url_host = parse_url($event->url, PHP_URL_HOST);
+        // If logging of content is on then
+        if (config('mail-tracker.log-content', true)) {
+            if ($event->sent_email && !empty($event->sent_email->domains_in_context) && in_array($url_host, $event->sent_email->domains_in_context)) {
+                $event->valid = true;
+            }
+        }
+    }
+}

--- a/src/MailTracker.php
+++ b/src/MailTracker.php
@@ -9,6 +9,7 @@ use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\SentMessage;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use jdavidbakr\MailTracker\Contracts\SentEmailModel;
 use jdavidbakr\MailTracker\Events\EmailSentEvent;
@@ -214,25 +215,13 @@ class MailTracker
             $url = str_replace('&amp;', '&', $matches[2]);
         }
 
-        return $matches[1].route(
+        return $matches[1].URL::signedRoute(
             'mailTracker_n',
             [
                 'l' => $url,
-                'h' => $this->hash
+                'h' => $this->hash,
             ]
         );
-    }
-
-    /**
-     * Legacy function
-     *
-     * @param [type] $url
-     * @return boolean
-     */
-    public static function hash_url($url)
-    {
-        // Replace "/" with "$"
-        return str_replace("/", "$", base64_encode($url));
     }
 
     /**

--- a/src/MailTrackerServiceProvider.php
+++ b/src/MailTrackerServiceProvider.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use jdavidbakr\MailTracker\Events\ValidLinkEvent;
+use jdavidbakr\MailTracker\Listener\DomainExistsInContentListener;
 use jdavidbakr\MailTracker\Middleware\ValidateSignature;
 
 class MailTrackerServiceProvider extends ServiceProvider
@@ -39,6 +41,13 @@ class MailTrackerServiceProvider extends ServiceProvider
             $tracker = new MailTracker;
             $tracker->messageSent($mail);
         });
+
+        foreach (config('mail-tracker.fallback-event-listeners', [
+            DomainExistsInContentListener::class,
+        ]) as $listener) {
+            // This event is only fired when the ValidateSignature middleware is not able to validate the link
+            Event::listen(ValidLinkEvent::class, $listener);
+        }
 
         // Install the routes
         $this->installRoutes();

--- a/src/Middleware/ValidateSignature.php
+++ b/src/Middleware/ValidateSignature.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace jdavidbakr\MailTracker\Middleware;
+
+use Closure;
+use Illuminate\Routing\Exceptions\InvalidSignatureException;
+use Illuminate\Routing\Middleware\ValidateSignature as Middleware;
+use Illuminate\Support\Carbon;
+use jdavidbakr\MailTracker\MailTracker;
+use jdavidbakr\MailTracker\Model\SentEmail;
+
+class ValidateSignature extends Middleware
+{
+    public function handle($request, Closure $next, $relative = null)
+    {
+        $ignore = property_exists($this, 'except') ? $this->except : $this->ignore;
+
+        if ($request->hasValidSignatureWhileIgnoring($ignore, $relative !== 'relative')) {
+            return $next($request);
+        }
+
+        // Temporary measure to allow for legacy URLs that do not have a signature
+        if (Carbon::now()->format('Y-m-d') < config('mail-tracker.signed_route_enforcement.start_date')) {
+            // Is the tracked email within the grace period?
+            /** @var SentEmail $tracker */
+            if ($tracker = MailTracker::sentEmailModel()->newQuery()->where('hash', $request->get('h'))->first()) {
+                if ($tracker->created_at->greaterThanOrEqualTo(Carbon::now()->subDays(config('mail-tracker.signed_route_enforcement.grace_period_days'))->startOfDay())) {
+                    // If the email is within the grace period, we allow the redirect
+                    return $next($request);
+                }
+            }
+        }
+
+        throw new InvalidSignatureException;
+    }
+}

--- a/src/Middleware/ValidateSignature.php
+++ b/src/Middleware/ValidateSignature.php
@@ -12,10 +12,8 @@ use jdavidbakr\MailTracker\Model\SentEmail;
 
 class ValidateSignature extends Middleware
 {
-    public function handle($request, Closure $next, $relative = null)
+    public function handle($request, Closure $next, ...$args)
     {
-        $ignore = property_exists($this, 'except') ? $this->except : $this->ignore;
-
         $hash = $request->get('h');
         $url  = $request->get('l');
 
@@ -23,8 +21,10 @@ class ValidateSignature extends Middleware
             throw new BadUrlLink('Mail hash: ' . $hash . ', URL: ' . $url);
         }
 
+        [$relative, $ignore] = $this->parseArguments($args);
+
         // If the signature is valid then we know that it has not been tampered with so continue
-        if ($request->hasValidSignatureWhileIgnoring($ignore, $relative !== 'relative')) {
+        if ($request->hasValidSignatureWhileIgnoring($ignore, ! $relative)) {
             return $next($request);
         }
 

--- a/src/Model/SentEmail.php
+++ b/src/Model/SentEmail.php
@@ -17,7 +17,11 @@ use jdavidbakr\MailTracker\Contracts\SentEmailModel;
  * @property int $opens
  * @property int $clicks
  * @property int|null $message_id
- * @property Collection $meta
+ * @property Collection|null $meta
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $clicked_at
+ * @property \Illuminate\Support\Carbon|null $opened_at
  */
 class SentEmail extends Model implements SentEmailModel
 {

--- a/tests/MailTrackerControllerTest.php
+++ b/tests/MailTrackerControllerTest.php
@@ -4,6 +4,7 @@ namespace jdavidbakr\MailTracker\Tests;
 
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use jdavidbakr\MailTracker\Events\ValidActionEvent;
 use jdavidbakr\MailTracker\MailTracker;
@@ -87,9 +88,9 @@ class MailTrackerControllerTest extends SetUpTest
 
         $redirect = 'http://' . Str::random(15) . '.com/' . Str::random(10) . '/' . Str::random(10) . '/' . rand(0, 100) . '/' . rand(0, 100) . '?page=' . rand(0, 100) . '&x=' . Str::random(32);
 
-        $this->get(route('mailTracker_l', [
-            MailTracker::hash_url($redirect), // Replace slash with dollar sign
-            $email->hash,
+        $this->get(URL::signedRoute('mailTracker_n', [
+            'n' => $redirect,
+            'h' => $email->hash,
         ]));
 
         $email->refresh();
@@ -115,9 +116,9 @@ class MailTrackerControllerTest extends SetUpTest
 
         $redirect = 'http://' . Str::random(15) . '.com/' . Str::random(10) . '/' . Str::random(10) . '/' . rand(0, 100) . '/' . rand(0, 100) . '?page=' . rand(0, 100) . '&x=' . Str::random(32);
 
-        $this->get(route('mailTracker_l', [
-            MailTracker::hash_url($redirect), // Replace slash with dollar sign
-            $email->hash,
+        $this->get(URL::signedRoute('mailTracker_n', [
+            'l' => $redirect,
+            'h' => $email->hash,
         ]));
 
         $email->refresh();

--- a/tests/MailTrackerTest.php
+++ b/tests/MailTrackerTest.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
 use jdavidbakr\MailTracker\Events\EmailSentEvent;
@@ -43,9 +44,11 @@ class IgnoreExceptions extends Handler
     public function __construct()
     {
     }
+
     public function report(Throwable $e)
     {
     }
+
     public function render($request, Throwable $e)
     {
         throw $e;
@@ -75,12 +78,12 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail-tracker.track-links', 1);
 
         $old_email = MailTracker::sentEmailModel()->newQuery()->create([
-                'hash' => Str::random(32),
-            ]);
-        $old_url = MailTracker::sentEmailUrlClickedModel()->newQuery()->create([
-                'sent_email_id' => $old_email->id,
-                'hash' => Str::random(32),
-            ]);
+            'hash' => Str::random(32),
+        ]);
+        $old_url   = MailTracker::sentEmailUrlClickedModel()->newQuery()->create([
+            'sent_email_id' => $old_email->id,
+            'hash'          => Str::random(32),
+        ]);
         // Go into the future to make sure that the old email gets removed
         \Carbon\Carbon::setTestNow(\Carbon\Carbon::now()->addWeek());
         $str = Mockery::mock(Str::class);
@@ -90,13 +93,13 @@ class MailTrackerTest extends SetUpTest
             ->andReturn('random-hash');
 
         Event::fake([
-            EmailSentEvent::class
+            EmailSentEvent::class,
         ]);
 
-        $faker = Factory::create();
-        $email = $faker->email;
+        $faker   = Factory::create();
+        $email   = $faker->email;
         $subject = $faker->sentence;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $name    = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
         try {
             Mail::send('email.test', [], function ($message) use ($email, $subject, $name) {
@@ -120,19 +123,19 @@ class MailTrackerTest extends SetUpTest
         Event::assertDispatched(EmailSentEvent::class);
 
         $this->assertDatabaseHas('sent_emails', [
-                'hash' => 'random-hash',
-                'recipient_name' => $name,
-                'recipient_email' => $email,
-                'sender_name' => 'From Name',
-                'sender_email' => 'from@johndoe.com',
-                'subject' => $subject,
-                'opened_at' => null,
-                'clicked_at' => null,
-            ]);
+            'hash'            => 'random-hash',
+            'recipient_name'  => $name,
+            'recipient_email' => $email,
+            'sender_name'     => 'From Name',
+            'sender_email'    => 'from@johndoe.com',
+            'subject'         => $subject,
+            'opened_at'       => null,
+            'clicked_at'      => null,
+        ]);
         $sent_email = MailTracker::sentEmailModel()->newQuery()->where([
             'hash' => 'random-hash',
         ])->first();
-        $this->assertEquals($name.' <'.$email.'>', $sent_email->recipient);
+        $this->assertEquals($name . ' <' . $email . '>', $sent_email->recipient);
         $this->assertEquals('From Name <from@johndoe.com>', $sent_email->sender);
         $this->assertNull($old_email->fresh());
         $this->assertNull($old_url->fresh());
@@ -140,9 +143,9 @@ class MailTrackerTest extends SetUpTest
 
     public function testSendMessageWithMailRaw()
     {
-        $faker = Factory::create();
-        $email = $faker->email;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $faker   = Factory::create();
+        $email   = $faker->email;
+        $name    = $faker->firstName . ' ' . $faker->lastName;
         $content = 'Text to e-mail';
         View::addLocation(__DIR__);
         $str = Mockery::mock(Str::class);
@@ -161,12 +164,12 @@ class MailTrackerTest extends SetUpTest
         }
 
         $this->assertDatabaseHas('sent_emails', [
-            'hash' => 'random-hash',
-            'sender_name' => 'From Name',
-            'sender_email' => 'from@johndoe.com',
-            'recipient_name' => $name,
+            'hash'            => 'random-hash',
+            'sender_name'     => 'From Name',
+            'sender_email'    => 'from@johndoe.com',
+            'recipient_name'  => $name,
             'recipient_email' => $email,
-            'content' => $content
+            'content'         => $content,
         ]);
     }
 
@@ -174,7 +177,7 @@ class MailTrackerTest extends SetUpTest
     {
         $faker = Factory::create();
         $email = $faker->email;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $name  = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
         $str = Mockery::mock(Str::class);
         app()->instance(Str::class, $str);
@@ -191,7 +194,7 @@ class MailTrackerTest extends SetUpTest
         }
 
         $this->assertDatabaseHas('sent_emails', [
-            'hash' => 'random-hash',
+            'hash'            => 'random-hash',
             'recipient_email' => $email,
         ]);
     }
@@ -200,7 +203,7 @@ class MailTrackerTest extends SetUpTest
     {
         $faker = Factory::create();
         $email = $faker->email;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $name  = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
         $str = Mockery::mock(Str::class);
         app()->instance(Str::class, $str);
@@ -209,7 +212,7 @@ class MailTrackerTest extends SetUpTest
             ->andReturn('random-hash');
         $mailable = new TestMailable();
         $mailable->subject('this is  the message subject.');
-        $mailable->attach(__DIR__.'/email/test.blade.php');
+        $mailable->attach(__DIR__ . '/email/test.blade.php');
 
         try {
             Mail::to($email)->send($mailable);
@@ -218,7 +221,7 @@ class MailTrackerTest extends SetUpTest
         }
 
         $this->assertDatabaseHas('sent_emails', [
-            'hash' => 'random-hash',
+            'hash'            => 'random-hash',
             'recipient_email' => $email,
         ]);
     }
@@ -227,7 +230,7 @@ class MailTrackerTest extends SetUpTest
     {
         $faker = Factory::create();
         $email = $faker->email;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $name  = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
         $str = Mockery::mock(Str::class);
         app()->instance(Str::class, $str);
@@ -256,7 +259,7 @@ class MailTrackerTest extends SetUpTest
         }
 
         $this->assertDatabaseHas('sent_emails', [
-            'hash' => 'random-hash',
+            'hash'            => 'random-hash',
             'recipient_email' => $email,
         ]);
     }
@@ -274,19 +277,18 @@ class MailTrackerTest extends SetUpTest
 
         $mailable = new TestMailable();
         $mailable->subject('this is  the message subject.');
-        $mailable->attach(__DIR__.'/email/example.pdf', [
-            'as' => 'invoice.pdf',
+        $mailable->attach(__DIR__ . '/email/example.pdf', [
+            'as'   => 'invoice.pdf',
             'mime' => 'application/pdf',
         ]);
 
         try {
             Mail::to($email)->send($mailable);
         } catch (Exception $e) {
-            // dd($e);
         }
 
         $this->assertDatabaseHas('sent_emails', [
-            'hash' => 'random-hash',
+            'hash'            => 'random-hash',
             'recipient_email' => $email,
         ]);
     }
@@ -296,11 +298,11 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_doesnt_track_if_told_not_to()
     {
-        $faker = Factory::create();
-        $email = $faker->email;
+        $faker        = Factory::create();
+        $email        = $faker->email;
         $anotherEmail = $faker->email;
-        $subject = $faker->sentence;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $subject      = $faker->sentence;
+        $name         = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
         try {
             Mail::send('email.test', [], function ($message) use ($email, $anotherEmail, $subject, $name) {
@@ -325,18 +327,18 @@ class MailTrackerTest extends SetUpTest
         }
 
         $this->assertDatabaseMissing('sent_emails', [
-            'subject' => $subject,
-            'sender_name' => 'From Name',
-            'sender_email' => 'from@johndoe.com',
-            'recipient_name' => $name,
+            'subject'         => $subject,
+            'sender_name'     => 'From Name',
+            'sender_email'    => 'from@johndoe.com',
+            'recipient_name'  => $name,
             'recipient_email' => $email,
         ]);
 
         $this->assertDatabaseMissing('sent_emails', [
-            'subject' => $subject,
-            'sender_name' => 'From Name',
-            'sender_email' => 'from@johndoe.com',
-            'recipient_name' => $name,
+            'subject'         => $subject,
+            'sender_name'     => 'From Name',
+            'sender_email'    => 'from@johndoe.com',
+            'recipient_name'  => $name,
             'recipient_email' => $anotherEmail,
         ]);
     }
@@ -349,23 +351,24 @@ class MailTrackerTest extends SetUpTest
         Carbon::setTestNow(now());
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
+
         $track = MailTracker::sentEmailModel()->newQuery()->create([
-                'hash' => Str::random(32),
-            ]);
-        $pings = $track->opens;
-        $pings++;
+            'hash' => Str::random(32),
+        ]);
+
         $url = route('mailTracker_t', [$track->hash]);
 
-        $response = $this->get($url);
+        $this->get($url)
+            ->assertSuccessful();
 
-        $response->assertSuccessful();
         Bus::assertDispatched(RecordTrackingJob::class, function ($e) use ($track) {
             return $e->sentEmail->id == $track->id &&
                 $e->ipAddress == '127.0.0.1' &&
                 $e->queue == 'alt-queue';
         });
+
         $this->assertDatabaseHas('sent_emails', [
-            'id' => $track->id,
+            'id'        => $track->id,
             'opened_at' => now()->format("Y-m-d H:i:s"),
         ]);
     }
@@ -379,11 +382,10 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
         $track = MailTracker::sentEmailModel()->newQuery()->create([
-                'hash' => Str::random(32),
-                'opened_at' => now()->subDays(10),
-            ]);
-        $pings = $track->opens;
-        $pings++;
+            'hash'      => Str::random(32),
+            'opened_at' => now()->subDays(10),
+        ]);
+
         $url = route('mailTracker_t', [$track->hash]);
 
         $response = $this->get($url);
@@ -395,40 +397,8 @@ class MailTrackerTest extends SetUpTest
                 $e->queue == 'alt-queue';
         });
         $this->assertDatabaseHas('sent_emails', [
-            'id' => $track->id,
+            'id'        => $track->id,
             'opened_at' => $track->opened_at,
-        ]);
-    }
-
-    public function testLegacyLink()
-    {
-        Carbon::setTestNow(now());
-        Config::set('mail-tracker.tracker-queue', 'alt-queue');
-        Bus::fake();
-        $redirect = 'http://'.Str::random(15).'.com/'.Str::random(10).'/'.Str::random(10).'/'.rand(0, 100).'/'.rand(0, 100).'?page='.rand(0, 100).'&x='.Str::random(32);
-
-        $track = MailTracker::sentEmailModel()->newQuery()->create([
-                'hash' => Str::random(32),
-                'content' => 'Hello, visit my website <a href="'.$redirect.'">'.$redirect.'</a>',
-            ]);
-        $clicks = $track->clicks;
-        $clicks++;
-        $url = route('mailTracker_l', [
-                MailTracker::hash_url($redirect), // Replace slash with dollar sign
-                $track->hash
-            ]);
-        $response = $this->get($url);
-
-        $response->assertRedirect($redirect);
-        Bus::assertDispatched(RecordLinkClickJob::class, function ($job) use ($track, $redirect) {
-            return $job->sentEmail->id == $track->id &&
-                $job->url == $redirect &&
-                $job->ipAddress == '127.0.0.1' &&
-                $job->queue == 'alt-queue';
-        });
-        $this->assertDatabaseHas('sent_emails', [
-            'id' => $track->id,
-            'clicked_at' => now()->format("Y-m-d H:i:s"),
         ]);
     }
 
@@ -438,15 +408,15 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail-tracker.inject-pixel', true);
         Config::set('mail-tracker.tracker-queue', 'alt-queue');
         Bus::fake();
-        $redirect = 'http://'.Str::random(15).'.com/'.Str::random(10).'/'.Str::random(10).'/'.rand(0, 100).'/'.rand(0, 100).'?page='.rand(0, 100).'&x='.Str::random(32);
-        $track = MailTracker::sentEmailModel()->newQuery()->create([
-                'hash' => Str::random(32),
-                'content' => 'Hello, visit my website <a href="'.$redirect.'">'.$redirect.'</a>',
-            ]);
-        $url = route('mailTracker_n', [
-                'l' => $redirect,
-                'h' => $track->hash
-            ]);
+        $redirect = 'http://' . Str::random(15) . '.com/' . Str::random(10) . '/' . Str::random(10) . '/' . rand(0, 100) . '/' . rand(0, 100) . '?page=' . rand(0, 100) . '&x=' . Str::random(32);
+        $track    = MailTracker::sentEmailModel()->newQuery()->create([
+            'hash'    => Str::random(32),
+            'content' => 'Hello, visit my website <a href="' . $redirect . '">' . $redirect . '</a>',
+        ]);
+        $url      = URL::signedRoute('mailTracker_n', [
+            'l' => $redirect,
+            'h' => $track->hash,
+        ]);
 
         $response = $this->get($url);
 
@@ -458,9 +428,9 @@ class MailTrackerTest extends SetUpTest
                 $job->queue == 'alt-queue';
         });
         $this->assertDatabaseHas('sent_emails', [
-            'id' => $track->id,
+            'id'         => $track->id,
             'clicked_at' => now()->format("Y-m-d H:i:s"),
-            'opened_at' => now()->format("Y-m-d H:i:s"),
+            'opened_at'  => now()->format("Y-m-d H:i:s"),
         ]);
     }
 
@@ -469,24 +439,21 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_redirects_to_fallback_if_the_sent_email_does_not_exists()
     {
-        $track = MailTracker::sentEmailModel()->newQuery()->create([
-                'hash' => Str::random(32),
-            ]);
-
-        $clicks = $track->clicks;
-        $clicks++;
+        MailTracker::sentEmailModel()->newQuery()->create([
+            'hash' => Str::random(32),
+        ]);
 
         Config::set('mail-tracker.redirect-missing-links-to', '/home');
-        $redirect = 'http://'.Str::random(15).'.com/'.Str::random(10).'/'.Str::random(10).'/'.rand(0, 100).'/'.rand(0, 100).'?page='.rand(0, 100).'&x='.Str::random(32);
+        $redirect = 'http://' . Str::random(15) . '.com/' . Str::random(10) . '/' . Str::random(10) . '/' . rand(0, 100) . '/' . rand(0, 100) . '?page=' . rand(0, 100) . '&x=' . Str::random(32);
 
         // Do it with an invalid hash
-        $url = route('mailTracker_n', [
-                'l' => $redirect,
-                'h' => 'bad-hash'
-            ]);
-        $response = $this->get($url);
+        $url = URL::signedRoute('mailTracker_n', [
+            'l' => $redirect,
+            'h' => 'bad-hash',
+        ]);
 
-        $response->assertRedirect('/home');
+        $this->get($url)
+            ->assertRedirect('/home');
     }
 
 
@@ -497,7 +464,7 @@ class MailTrackerTest extends SetUpTest
     {
         Event::fake();
         $track = MailTracker::sentEmailModel()->newQuery()->create([
-            'hash' => Str::random(32),
+            'hash'    => Str::random(32),
             'content' => 'This is some content with a link to <a href="https://goodwebsite.com">Good website</a>',
         ]);
 
@@ -505,45 +472,20 @@ class MailTrackerTest extends SetUpTest
 
         $invalidUrl = 'http://evil.com'; // Domain not present in email content
 
-        $response = $this->get(route('mailTracker_l', [MailTracker::hash_url($invalidUrl), $track->hash]));
-
-        $response->assertRedirect('/home');
+        $this->get(URL::signedRoute('mailTracker_n', ['l' => $invalidUrl, 'h' => $track->hash]))
+            ->assertRedirect('/home');
     }
 
     /**
      * @test
      */
-    public function it_redirects_to_config_page_if_no_url_in_request()
-    {
-        Config::set('mail-tracker.redirect-missing-links-to', '/home');
-
-        $url = route('mailTracker_n');
-        $response = $this->get($url);
-
-        $response->assertRedirect('/home');
-    }
-
-    /**
-     * @test
-     */
-    public function it_redirects_to_home_page_if_no_url_in_request()
-    {
-        $url = route('mailTracker_n');
-        $response = $this->get($url);
-
-        $response->assertRedirect('/');
-    }
-
-    /**
-     * @test
-     */
-    public function random_string_in_link_does_not_crash(Type $var = null)
+    public function random_string_in_link_does_not_crash()
     {
         $this->disableExceptionHandling();
         $this->expectException(BadUrlLink::class);
-        $url = route('mailTracker_l', [
-            Str::random(32),
-            'the-mail-hash',
+        $url = URL::signedRoute('mailTracker_n', [
+            'l' => Str::random(32),
+            'h' => 'the-mail-hash',
         ]);
 
         $this->get($url);
@@ -552,119 +494,119 @@ class MailTrackerTest extends SetUpTest
     /**
      * @test
      */
-    public function it_retrieves_the_mesage_id_from_laravel_mailer()
+    public function it_retrieves_the_message_id_from_laravel_mailer()
     {
-        $sent = MailTracker::sentEmailModel()->newQuery()->create([
-            'hash'=>'the-hash',
-            'message_id'=>'to-be-replaced',
+        $sent    = MailTracker::sentEmailModel()->newQuery()->create([
+            'hash'       => 'the-hash',
+            'message_id' => 'to-be-replaced',
         ]);
         $headers = new Headers;
         $headers->addHeader('X-Mailer-Hash', $sent->hash);
-        $sendingEvent = Mockery::mock(MessageSending::class);
+        $sendingEvent          = Mockery::mock(MessageSending::class);
         $sendingEvent->message = Mockery::mock(Email::class, [
-                'getTo' => [
-                    Mockery::mock([
-                        'getAddress'=>'destination@example.com',
-                        'getName'=>'Destination Person'
-                    ])
-                ],
-                'getFrom' => [
-                    Mockery::mock([
-                        'getAddress'=>'from@example.com',
-                        'getName'=>'From Name'
-                    ])
-                ],
-                'getHeaders' => $headers,
-                'getSubject' => 'The message subject',
-                'getBody' => Mockery::mock(AbstractPart::class, [
-                    'getBody'=>'The body',
-                    'getMediaType'=>'text',
-                    'getMediaSubtype'=>'html',
+            'getTo'          => [
+                Mockery::mock([
+                    'getAddress' => 'destination@example.com',
+                    'getName'    => 'Destination Person',
                 ]),
-                'setBody' => Mockery::Mock(Email::class),
-                'getChildren' => [],
-                'getId' => 'message-id',
-                'getHtmlCharset' => 'utf-8',
-            ]);
-        $sentEvent = Mockery::mock(MessageSent::class);
-        $sentEvent->sent = Mockery::mock(SentMessage::class, [
-            'getOriginalMessage'=>Mockery::mock([
-                'getHeaders'=>$headers
+            ],
+            'getFrom'        => [
+                Mockery::mock([
+                    'getAddress' => 'from@example.com',
+                    'getName'    => 'From Name',
+                ]),
+            ],
+            'getHeaders'     => $headers,
+            'getSubject'     => 'The message subject',
+            'getBody'        => Mockery::mock(AbstractPart::class, [
+                'getBody'         => 'The body',
+                'getMediaType'    => 'text',
+                'getMediaSubtype' => 'html',
             ]),
-            'getMessageId'=>'native-id',
+            'setBody'        => Mockery::Mock(Email::class),
+            'getChildren'    => [],
+            'getId'          => 'message-id',
+            'getHtmlCharset' => 'utf-8',
         ]);
-        $tracker = new MailTracker();
+        $sentEvent             = Mockery::mock(MessageSent::class);
+        $sentEvent->sent       = Mockery::mock(SentMessage::class, [
+            'getOriginalMessage' => Mockery::mock([
+                'getHeaders' => $headers,
+            ]),
+            'getMessageId'       => 'native-id',
+        ]);
+        $tracker               = new MailTracker();
 
         $tracker->messageSending($sendingEvent);
         $tracker->messageSent($sentEvent);
 
         $this->assertDatabaseHas('sent_emails', [
-            'id'=>$sent->id,
-            'message_id'=>'native-id'
+            'id'         => $sent->id,
+            'message_id' => 'native-id',
         ]);
     }
 
     /**
      * @test
      */
-    public function it_retrieves_the_mesage_id_from_ses_mail_default()
+    public function it_retrieves_the_message_id_from_ses_mail_default()
     {
         Config::set('mail.default', 'ses');
         Config::set('mail.driver', null);
-        $sent = MailTracker::sentEmailModel()->newQuery()->create([
-            'hash'=>'the-hash',
-            'message_id'=>'to-be-replaced',
+        $sent    = MailTracker::sentEmailModel()->newQuery()->create([
+            'hash'       => 'the-hash',
+            'message_id' => 'to-be-replaced',
         ]);
         $headers = new Headers;
         $headers->addHeader('X-Mailer-Hash', $sent->hash);
         $headers->addHeader('X-SES-Message-ID', 'aws-mailer-hash');
-        $sendingEvent = Mockery::mock(MessageSending::class);
+        $sendingEvent          = Mockery::mock(MessageSending::class);
         $sendingEvent->message = Mockery::mock(Email::class, [
-                'getTo' => [
-                    Mockery::mock([
-                        'getAddress'=>'destination@example.com',
-                        'getName'=>'Destination Person'
-                    ])
-                ],
-                'getFrom' => [
-                    Mockery::mock([
-                        'getAddress'=>'from@example.com',
-                        'getName'=>'From Name'
-                    ])
-                ],
-                'getHeaders' => $headers,
-                'getSubject' => 'The message subject',
-                'getBody' => Mockery::mock(AbstractPart::class, 'content', [
-                    'getBody'=>'The body',
-                    'getMediaType'=>'text',
-                    'getMediaSubtype'=>'html',
+            'getTo'          => [
+                Mockery::mock([
+                    'getAddress' => 'destination@example.com',
+                    'getName'    => 'Destination Person',
                 ]),
-                'setBody' => Mockery::mock(Email::class),
-                'getChildren' => [],
-                'getId' => 'message-id',
-                'getHtmlCharset' => 'utf-8',
-            ]);
-        $sentEvent = Mockery::mock(MessageSent::class);
-        $sentEvent->sent = Mockery::mock(SentMessage::class, [
-            'getOriginalMessage'=>Mockery::mock([
-                'getHeaders'=>$headers
+            ],
+            'getFrom'        => [
+                Mockery::mock([
+                    'getAddress' => 'from@example.com',
+                    'getName'    => 'From Name',
+                ]),
+            ],
+            'getHeaders'     => $headers,
+            'getSubject'     => 'The message subject',
+            'getBody'        => Mockery::mock(AbstractPart::class, 'content', [
+                'getBody'         => 'The body',
+                'getMediaType'    => 'text',
+                'getMediaSubtype' => 'html',
+            ]),
+            'setBody'        => Mockery::mock(Email::class),
+            'getChildren'    => [],
+            'getId'          => 'message-id',
+            'getHtmlCharset' => 'utf-8',
+        ]);
+        $sentEvent             = Mockery::mock(MessageSent::class);
+        $sentEvent->sent       = Mockery::mock(SentMessage::class, [
+            'getOriginalMessage' => Mockery::mock([
+                'getHeaders' => $headers,
             ]),
         ]);
-        $tracker = new MailTracker();
+        $tracker               = new MailTracker();
 
         $tracker->messageSending($sendingEvent);
         $tracker->messageSent($sentEvent);
 
         $this->assertDatabaseHas('sent_emails', [
-            'id'=>$sent->id,
-            'message_id'=>'aws-mailer-hash'
+            'id'         => $sent->id,
+            'message_id' => 'aws-mailer-hash',
         ]);
     }
 
     /**
      * @test
      */
-    public function it_retrieves_the_mesage_id_from_ses_mail_driver()
+    public function it_retrieves_the_message_id_from_ses_mail_driver()
     {
         $str = Mockery::mock(Str::class);
         app()->instance(Str::class, $str);
@@ -673,53 +615,53 @@ class MailTrackerTest extends SetUpTest
             ->andReturn('random-hash');
         Config::set('mail.driver', 'ses');
         Config::set('mail.default', null);
-        $sent = MailTracker::sentEmailModel()->newQuery()->create([
-            'hash'=>'the-hash',
-            'message_id'=>'to-be-replaced',
+        $sent    = MailTracker::sentEmailModel()->newQuery()->create([
+            'hash'       => 'the-hash',
+            'message_id' => 'to-be-replaced',
         ]);
         $headers = new Headers;
         $headers->addHeader('X-Mailer-Hash', $sent->hash);
         $headers->addHeader('X-SES-Message-ID', 'aws-mailer-hash');
-        $sendingEvent = Mockery::mock(MessageSending::class);
+        $sendingEvent          = Mockery::mock(MessageSending::class);
         $sendingEvent->message = Mockery::mock(Email::class, [
-                'getTo' => [
-                    Mockery::mock([
-                        'getAddress'=>'destination@example.com',
-                        'getName'=>'Destination Person'
-                    ])
-                ],
-                'getFrom' => [
-                    Mockery::mock([
-                        'getAddress'=>'from@example.com',
-                        'getName'=>'From Name'
-                    ])
-                ],
-                'getHeaders' => $headers,
-                'getSubject' => 'The message subject',
-                'getBody' => Mockery::mock(AbstractPart::class, 'content', [
-                    'getBody'=>'The body',
-                    'getMediaType'=>'text',
-                    'getMediaSubtype'=>'html',
+            'getTo'          => [
+                Mockery::mock([
+                    'getAddress' => 'destination@example.com',
+                    'getName'    => 'Destination Person',
                 ]),
-                'setBody' => Mockery::mock(Email::class),
-                'getChildren' => [],
-                'getId' => 'message-id',
-                'getHtmlCharset' => 'utf-8',
-            ]);
-        $sentEvent = Mockery::mock(MessageSent::class);
-        $sentEvent->sent = Mockery::mock(SentMessage::class, [
-            'getOriginalMessage'=>Mockery::mock([
-                'getHeaders'=>$headers
+            ],
+            'getFrom'        => [
+                Mockery::mock([
+                    'getAddress' => 'from@example.com',
+                    'getName'    => 'From Name',
+                ]),
+            ],
+            'getHeaders'     => $headers,
+            'getSubject'     => 'The message subject',
+            'getBody'        => Mockery::mock(AbstractPart::class, 'content', [
+                'getBody'         => 'The body',
+                'getMediaType'    => 'text',
+                'getMediaSubtype' => 'html',
+            ]),
+            'setBody'        => Mockery::mock(Email::class),
+            'getChildren'    => [],
+            'getId'          => 'message-id',
+            'getHtmlCharset' => 'utf-8',
+        ]);
+        $sentEvent             = Mockery::mock(MessageSent::class);
+        $sentEvent->sent       = Mockery::mock(SentMessage::class, [
+            'getOriginalMessage' => Mockery::mock([
+                'getHeaders' => $headers,
             ]),
         ]);
-        $tracker = new MailTracker();
+        $tracker               = new MailTracker();
 
         $tracker->messageSending($sendingEvent);
         $tracker->messageSent($sentEvent);
 
         $this->assertDatabaseHas('sent_emails', [
-            'id'=>$sent->id,
-            'message_id'=>'aws-mailer-hash'
+            'id'         => $sent->id,
+            'message_id' => 'aws-mailer-hash',
         ]);
     }
 
@@ -732,23 +674,23 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_confirms_a_subscription()
     {
-        $url = action('\jdavidbakr\MailTracker\SNSController@callback');
+        $url      = action('\jdavidbakr\MailTracker\SNSController@callback');
         $response = $this->post($url, [
-                'message' => json_encode([
-                        // Required
-                        'Message' => 'test subscription message',
-                        'MessageId' => Str::random(10),
-                        'Timestamp' => \Carbon\Carbon::now()->timestamp,
-                        'TopicArn' => Str::random(10),
-                        'Type' => 'SubscriptionConfirmation',
-                        'Signature' => Str::random(32),
-                        'SigningCertURL' => Str::random(32),
-                        'SignatureVersion' => 1,
-                        // Request-specific
-                        'SubscribeURL' => 'http://google.com',
-                        'Token' => Str::random(10),
-                    ])
-            ]);
+            'message' => json_encode([
+                // Required
+                'Message'          => 'test subscription message',
+                'MessageId'        => Str::random(10),
+                'Timestamp'        => \Carbon\Carbon::now()->timestamp,
+                'TopicArn'         => Str::random(10),
+                'Type'             => 'SubscriptionConfirmation',
+                'Signature'        => Str::random(32),
+                'SigningCertURL'   => Str::random(32),
+                'SignatureVersion' => 1,
+                // Request-specific
+                'SubscribeURL'     => 'http://google.com',
+                'Token'            => Str::random(10),
+            ]),
+        ]);
         $response->assertSee('subscription confirmed');
     }
 
@@ -759,23 +701,23 @@ class MailTrackerTest extends SetUpTest
     {
         $topic = Str::random(32);
         Config::set('mail-tracker.sns-topic', $topic);
-        $url = action('\jdavidbakr\MailTracker\SNSController@callback');
+        $url      = action('\jdavidbakr\MailTracker\SNSController@callback');
         $response = $this->post($url, [
-                'message' => json_encode([
-                        // Required
-                        'Message' => 'test subscription message',
-                        'MessageId' => Str::random(10),
-                        'Timestamp' => \Carbon\Carbon::now()->timestamp,
-                        'TopicArn' => $topic,
-                        'Type' => 'SubscriptionConfirmation',
-                        'Signature' => Str::random(32),
-                        'SigningCertURL' => Str::random(32),
-                        'SignatureVersion' => 1,
-                        // Request-specific
-                        'SubscribeURL' => 'http://google.com',
-                        'Token' => Str::random(10),
-                    ])
-            ]);
+            'message' => json_encode([
+                // Required
+                'Message'          => 'test subscription message',
+                'MessageId'        => Str::random(10),
+                'Timestamp'        => \Carbon\Carbon::now()->timestamp,
+                'TopicArn'         => $topic,
+                'Type'             => 'SubscriptionConfirmation',
+                'Signature'        => Str::random(32),
+                'SigningCertURL'   => Str::random(32),
+                'SignatureVersion' => 1,
+                // Request-specific
+                'SubscribeURL'     => 'http://google.com',
+                'Token'            => Str::random(10),
+            ]),
+        ]);
         $response->assertSee('subscription confirmed');
     }
 
@@ -786,23 +728,23 @@ class MailTrackerTest extends SetUpTest
     {
         $topic = Str::random(32);
         Config::set('mail-tracker.sns-topic', $topic);
-        $url = action('\jdavidbakr\MailTracker\SNSController@callback');
+        $url      = action('\jdavidbakr\MailTracker\SNSController@callback');
         $response = $this->post($url, [
-                'message' => json_encode([
-                        // Required
-                        'Message' => 'test subscription message',
-                        'MessageId' => Str::random(10),
-                        'Timestamp' => \Carbon\Carbon::now()->timestamp,
-                        'TopicArn' => Str::random(32),
-                        'Type' => 'SubscriptionConfirmation',
-                        'Signature' => Str::random(32),
-                        'SigningCertURL' => Str::random(32),
-                        'SignatureVersion' => 1,
-                        // Request-specific
-                        'SubscribeURL' => 'http://google.com',
-                        'Token' => Str::random(10),
-                    ])
-            ]);
+            'message' => json_encode([
+                // Required
+                'Message'          => 'test subscription message',
+                'MessageId'        => Str::random(10),
+                'Timestamp'        => \Carbon\Carbon::now()->timestamp,
+                'TopicArn'         => Str::random(32),
+                'Type'             => 'SubscriptionConfirmation',
+                'Signature'        => Str::random(32),
+                'SigningCertURL'   => Str::random(32),
+                'SignatureVersion' => 1,
+                // Request-specific
+                'SubscribeURL'     => 'http://google.com',
+                'Token'            => Str::random(10),
+            ]),
+        ]);
         $response->assertSee('invalid topic ARN');
     }
 
@@ -818,17 +760,17 @@ class MailTrackerTest extends SetUpTest
         ];
 
         $response = $this->post(action('\jdavidbakr\MailTracker\SNSController@callback'), [
-                'message' => json_encode([
-                    'Message' => json_encode($message),
-                    'MessageId' => Str::uuid(),
-                    'Timestamp' => Carbon::now()->timestamp,
-                    'TopicArn' => Str::uuid(),
-                    'Type' => 'Notification',
-                    'Signature' => Str::uuid(),
-                    'SigningCertURL' => Str::uuid(),
-                    'SignatureVersion' => Str::uuid(),
-                ])
-            ]);
+            'message' => json_encode([
+                'Message'          => json_encode($message),
+                'MessageId'        => Str::uuid(),
+                'Timestamp'        => Carbon::now()->timestamp,
+                'TopicArn'         => Str::uuid(),
+                'Type'             => 'Notification',
+                'Signature'        => Str::uuid(),
+                'SigningCertURL'   => Str::uuid(),
+                'SignatureVersion' => Str::uuid(),
+            ]),
+        ]);
 
         $response->assertSee('notification processed');
         Bus::assertDispatched(RecordDeliveryJob::class, function ($job) use ($message) {
@@ -849,17 +791,17 @@ class MailTrackerTest extends SetUpTest
         ];
 
         $response = $this->post(action('\jdavidbakr\MailTracker\SNSController@callback'), [
-                'message' => json_encode([
-                    'Message' => json_encode($message),
-                    'MessageId' => Str::uuid(),
-                    'Timestamp' => Carbon::now()->timestamp,
-                    'TopicArn' => Str::uuid(),
-                    'Type' => 'Notification',
-                    'Signature' => Str::uuid(),
-                    'SigningCertURL' => Str::uuid(),
-                    'SignatureVersion' => Str::uuid(),
-                ])
-            ]);
+            'message' => json_encode([
+                'Message'          => json_encode($message),
+                'MessageId'        => Str::uuid(),
+                'Timestamp'        => Carbon::now()->timestamp,
+                'TopicArn'         => Str::uuid(),
+                'Type'             => 'Notification',
+                'Signature'        => Str::uuid(),
+                'SigningCertURL'   => Str::uuid(),
+                'SignatureVersion' => Str::uuid(),
+            ]),
+        ]);
 
         $response->assertSee('notification processed');
         Bus::assertDispatched(RecordBounceJob::class, function ($job) use ($message) {
@@ -880,17 +822,17 @@ class MailTrackerTest extends SetUpTest
         ];
 
         $response = $this->post(action('\jdavidbakr\MailTracker\SNSController@callback'), [
-                'message' => json_encode([
-                    'Message' => json_encode($message),
-                    'MessageId' => Str::uuid(),
-                    'Timestamp' => Carbon::now()->timestamp,
-                    'TopicArn' => Str::uuid(),
-                    'Type' => 'Notification',
-                    'Signature' => Str::uuid(),
-                    'SigningCertURL' => Str::uuid(),
-                    'SignatureVersion' => Str::uuid(),
-                ])
-            ]);
+            'message' => json_encode([
+                'Message'          => json_encode($message),
+                'MessageId'        => Str::uuid(),
+                'Timestamp'        => Carbon::now()->timestamp,
+                'TopicArn'         => Str::uuid(),
+                'Type'             => 'Notification',
+                'Signature'        => Str::uuid(),
+                'SigningCertURL'   => Str::uuid(),
+                'SignatureVersion' => Str::uuid(),
+            ]),
+        ]);
 
         $response->assertSee('notification processed');
         Bus::assertDispatched(RecordComplaintJob::class, function ($job) use ($message) {
@@ -910,10 +852,10 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail.driver', 'array');
         (new MailServiceProvider(app()))->register();
 
-        $faker = Factory::create();
-        $email = $faker->email;
+        $faker   = Factory::create();
+        $email   = $faker->email;
         $subject = $faker->sentence;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $name    = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
 
         Mail::send('email.testAmpersand', [], function ($message) use ($email, $subject, $name) {
@@ -934,7 +876,7 @@ class MailTrackerTest extends SetUpTest
         $driver = app('mailer')->getSymfonyTransport();
         $this->assertEquals(1, count($driver->messages()));
 
-        $mes = $driver->messages()[0];
+        $mes  = $driver->messages()[0];
         $body = $mes->getOriginalMessage()->getBody()->getBody();
         $hash = $mes->getOriginalMessage()->getHeaders()->get('X-Mailer-Hash')->getValue();
 
@@ -953,7 +895,7 @@ class MailTrackerTest extends SetUpTest
         Event::assertDispatched(LinkClickedEvent::class);
 
         $this->assertDatabaseHas('sent_emails_url_clicked', [
-            'url' => $expected_url,
+            'url'    => $expected_url,
             'clicks' => 1,
         ]);
 
@@ -973,10 +915,10 @@ class MailTrackerTest extends SetUpTest
         Config::set('mail.driver', 'array');
         (new MailServiceProvider(app()))->register();
 
-        $faker = Factory::create();
-        $email = $faker->email;
+        $faker   = Factory::create();
+        $email   = $faker->email;
         $subject = $faker->sentence;
-        $name = $faker->firstName . ' ' . $faker->lastName;
+        $name    = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
 
         Mail::send('email.testApostrophe', [], function ($message) use ($email, $subject, $name) {
@@ -992,7 +934,7 @@ class MailTrackerTest extends SetUpTest
         $driver = app('mailer')->getSymfonyTransport();
         $this->assertEquals(1, count($driver->messages()));
 
-        $mes = $driver->messages()[0];
+        $mes  = $driver->messages()[0];
         $body = $mes->getOriginalMessage()->getBody()->getBody();
         $hash = $mes->getOriginalMessage()->getHeaders()->get('X-Mailer-Hash')->getValue();
 
@@ -1011,7 +953,7 @@ class MailTrackerTest extends SetUpTest
         Event::assertDispatched(LinkClickedEvent::class);
 
         $this->assertDatabaseHas('sent_emails_url_clicked', [
-            'url' => $expected_url,
+            'url'    => $expected_url,
             'clicks' => 1,
         ]);
 
@@ -1026,10 +968,10 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_retrieves_header_data()
     {
-        $faker = Factory::create();
-        $email = $faker->email;
-        $subject = $faker->sentence;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $faker       = Factory::create();
+        $email       = $faker->email;
+        $subject     = $faker->sentence;
+        $name        = $faker->firstName . ' ' . $faker->lastName;
         $header_test = Str::random(10);
         \View::addLocation(__DIR__);
         try {
@@ -1062,11 +1004,11 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_retrieves_long_header_data()
     {
-        $faker = Factory::create();
-        $email = $faker->email;
-        $subject = $faker->sentence;
-        $name = $faker->firstName . ' ' .$faker->lastName;
-        $header_test = Str::random(100) .', ' . Str::random(100) .', '. Str::random(100);
+        $faker       = Factory::create();
+        $email       = $faker->email;
+        $subject     = $faker->sentence;
+        $name        = $faker->firstName . ' ' . $faker->lastName;
+        $header_test = Str::random(100) . ', ' . Str::random(100) . ', ' . Str::random(100);
         View::addLocation(__DIR__);
         try {
             Mail::send('email.test', [], function ($message) use ($email, $subject, $name, $header_test) {
@@ -1098,10 +1040,10 @@ class MailTrackerTest extends SetUpTest
      */
     public function it_retrieves_multiple_cc_recipients_from_header_data()
     {
-        $faker = Factory::create();
-        $email = $faker->email;
+        $faker   = Factory::create();
+        $email   = $faker->email;
         $subject = $faker->sentence;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $name    = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
         try {
             Mail::send('email.test', [], function ($message) use ($email, $subject, $name) {
@@ -1161,21 +1103,21 @@ class MailTrackerTest extends SetUpTest
         $old_email = MailTracker::sentEmailModel()->newQuery()->create([
             'hash' => Str::random(32),
         ]);
-        $old_url = MailTracker::sentEmailUrlClickedModel()->newQuery()->create([
+        $old_url   = MailTracker::sentEmailUrlClickedModel()->newQuery()->create([
             'sent_email_id' => $old_email->id,
-            'hash' => Str::random(32),
+            'hash'          => Str::random(32),
         ]);
         // Go into the future to make sure that the old email gets removed
         \Carbon\Carbon::setTestNow(\Carbon\Carbon::now()->addWeek());
 
         Event::fake([
-            EmailSentEvent::class
+            EmailSentEvent::class,
         ]);
 
-        $faker = Factory::create();
-        $email = $faker->email;
+        $faker   = Factory::create();
+        $email   = $faker->email;
         $subject = $faker->sentence;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $name    = $faker->firstName . ' ' . $faker->lastName;
         \View::addLocation(__DIR__);
         try {
             \Mail::send('email.test', [], function ($message) use ($email, $subject, $name) {
@@ -1199,11 +1141,11 @@ class MailTrackerTest extends SetUpTest
         Event::assertDispatched(EmailSentEvent::class);
 
         $this->assertDatabaseHas('sent_emails', [
-            'recipient_name' => $name,
+            'recipient_name'  => $name,
             'recipient_email' => $email,
-            'sender_name' => 'From Name',
-            'sender_email' => 'from@johndoe.com',
-            'subject' => $subject,
+            'sender_name'     => 'From Name',
+            'sender_email'    => 'from@johndoe.com',
+            'subject'         => $subject,
         ], 'secondary');
         $this->assertNull($old_email->fresh());
         $this->assertNull($old_url->fresh());
@@ -1215,17 +1157,17 @@ class MailTrackerTest extends SetUpTest
     public function it_can_retrieve_url_clicks_from_eloquent()
     {
         Event::fake();
-        $track = MailTracker::sentEmailModel()->newQuery()->create([
+        $track             = MailTracker::sentEmailModel()->newQuery()->create([
             'hash' => Str::random(32),
         ]);
-        $message_id = Str::random(32);
+        $message_id        = Str::random(32);
         $track->message_id = $message_id;
         $track->save();
 
         $urlClick = MailTracker::sentEmailUrlClickedModel()->newQuery()->create([
             'sent_email_id' => $track->id,
-            'url' => 'https://example.com',
-            'hash' => Str::random(32)
+            'url'           => 'https://example.com',
+            'hash'          => Str::random(32),
         ]);
         $urlClick->save();
         $this->assertTrue($track->urlClicks->count() === 1);
@@ -1239,9 +1181,9 @@ class MailTrackerTest extends SetUpTest
     public function it_handles_headers_with_colons()
     {
         $headerData = '{"some_id":2,"some_othger_id":"0dd75231-31bb-4e67-8ab7-a83315f75a44","some_field":"A Field Value"}';
-        $track = MailTracker::sentEmailModel()->newQuery()->create([
-            'hash' => Str::random(32),
-            'headers' => 'X-MyHeader: '.$headerData,
+        $track      = MailTracker::sentEmailModel()->newQuery()->create([
+            'hash'    => Str::random(32),
+            'headers' => 'X-MyHeader: ' . $headerData,
         ]);
 
         $retrieval = $track->getHeader('X-MyHeader');
@@ -1251,9 +1193,9 @@ class MailTrackerTest extends SetUpTest
 
     public function testLogContentInFilesystem()
     {
-        $faker = Factory::create();
-        $email = $faker->email;
-        $name = $faker->firstName . ' ' .$faker->lastName;
+        $faker   = Factory::create();
+        $email   = $faker->email;
+        $name    = $faker->firstName . ' ' . $faker->lastName;
         $content = 'Text to e-mail';
         View::addLocation(__DIR__);
         $str = Mockery::mock(Str::class);
@@ -1267,7 +1209,7 @@ class MailTrackerTest extends SetUpTest
         config()->set('mail-tracker.tracker-filesystem', 'filesystem');
         config()->set('mail-tracker.tracker-filesystem-folder', 'mail-tracker');
         config()->set('filesystems.disks.testing.driver', 'local');
-        config()->set('filesystems.disks.testing.root', realpath(__DIR__.'/../storage'));
+        config()->set('filesystems.disks.testing.root', realpath(__DIR__ . '/../storage'));
         config()->set('filesystems.default', 'testing');
 
         Storage::fake(config('mail-tracker.tracker-filesystem'));
@@ -1282,19 +1224,19 @@ class MailTrackerTest extends SetUpTest
         }
 
         $this->assertDatabaseHas('sent_emails', [
-            'hash' => 'random-hash',
-            'sender_name' => 'From Name',
-            'sender_email' => 'from@johndoe.com',
-            'recipient_name' => $name,
+            'hash'            => 'random-hash',
+            'sender_name'     => 'From Name',
+            'sender_email'    => 'from@johndoe.com',
+            'recipient_name'  => $name,
             'recipient_email' => $email,
-            'content' => null
+            'content'         => null,
         ]);
 
-        $tracker = MailTracker::sentEmailModel()->newQuery()->where('hash', '=','random-hash')->first();
+        $tracker = MailTracker::sentEmailModel()->newQuery()->where('hash', '=', 'random-hash')->first();
         $this->assertNotNull($tracker);
         $this->assertEquals($content, $tracker->content);
-        $folder = config('mail-tracker.tracker-filesystem-folder', 'mail-tracker');
-        $filePath = $tracker->meta->get('content_file_path');
+        $folder       = config('mail-tracker.tracker-filesystem-folder', 'mail-tracker');
+        $filePath     = $tracker->meta->get('content_file_path');
         $expectedPath = "{$folder}/random-hash.html";
         $this->assertEquals($expectedPath, $filePath);
         Storage::disk(config('mail-tracker.tracker-filesystem'))->assertExists($filePath);

--- a/tests/MailTrackerTest.php
+++ b/tests/MailTrackerTest.php
@@ -2,7 +2,6 @@
 
 namespace jdavidbakr\MailTracker\Tests;
 
-use Exception;
 use Faker\Factory;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Database\Eloquent\Model;
@@ -33,7 +32,6 @@ use jdavidbakr\MailTracker\RecordLinkClickJob;
 use jdavidbakr\MailTracker\RecordTrackingJob;
 use Mockery;
 use Orchestra\Testbench\Exceptions\Handler;
-use Symfony\Component\Mailer\Exception\TransportException;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\Headers;
 use Symfony\Component\Mime\Part\AbstractPart;
@@ -101,24 +99,22 @@ class MailTrackerTest extends SetUpTest
         $subject = $faker->sentence;
         $name    = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
-        try {
-            Mail::send('email.test', [], function ($message) use ($email, $subject, $name) {
-                $message->from('from@johndoe.com', 'From Name');
-                $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->to($email, $name);
+        Mail::send('email.test', [], function ($message) use ($email, $subject, $name) {
+            $message->from('from@johndoe.com', 'From Name');
+            $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->cc('cc@johndoe.com', 'CC Name');
-                $message->bcc('bcc@johndoe.com', 'BCC Name');
+            $message->to($email, $name);
 
-                $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
+            $message->cc('cc@johndoe.com', 'CC Name');
+            $message->bcc('bcc@johndoe.com', 'BCC Name');
 
-                $message->subject($subject);
+            $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
 
-                $message->priority(3);
-            });
-        } catch (TransportException $e) {
-        }
+            $message->subject($subject);
+
+            $message->priority(3);
+        });
 
         Event::assertDispatched(EmailSentEvent::class);
 
@@ -154,14 +150,11 @@ class MailTrackerTest extends SetUpTest
             ->once()
             ->andReturn('random-hash');
 
-        try {
-            Mail::raw($content, function ($message) use ($email, $name) {
-                $message->from('from@johndoe.com', 'From Name');
+        Mail::raw($content, function ($message) use ($email, $name) {
+            $message->from('from@johndoe.com', 'From Name');
 
-                $message->to($email, $name);
-            });
-        } catch (Exception $e) {
-        }
+            $message->to($email, $name);
+        });
 
         $this->assertDatabaseHas('sent_emails', [
             'hash'            => 'random-hash',
@@ -187,11 +180,7 @@ class MailTrackerTest extends SetUpTest
         $mailable = new TestMailable();
         $mailable->subject('this is the message subject.');
 
-        try {
-            Mail::to($email)->send($mailable);
-        } catch (Exception $e) {
-            // dd($e);
-        }
+        Mail::to($email)->send($mailable);
 
         $this->assertDatabaseHas('sent_emails', [
             'hash'            => 'random-hash',
@@ -214,11 +203,7 @@ class MailTrackerTest extends SetUpTest
         $mailable->subject('this is  the message subject.');
         $mailable->attach(__DIR__ . '/email/test.blade.php');
 
-        try {
-            Mail::to($email)->send($mailable);
-        } catch (Exception $e) {
-            // dd($e);
-        }
+        Mail::to($email)->send($mailable);
 
         $this->assertDatabaseHas('sent_emails', [
             'hash'            => 'random-hash',
@@ -238,25 +223,21 @@ class MailTrackerTest extends SetUpTest
             ->once()
             ->andReturn('random-hash');
 
-        try {
-            Mail::send('email.embed-test', ['imagePath' => __DIR__ . '/email/example.png'], function ($message) use ($email, $name) {
-                $message->from('from@johndoe.com', 'From Name');
-                $message->sender('sender@johndoe.com', 'Sender Name');
+        Mail::send('email.embed-test', ['imagePath' => __DIR__ . '/email/example.png'], function ($message) use ($email, $name) {
+            $message->from('from@johndoe.com', 'From Name');
+            $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->to($email, $name);
+            $message->to($email, $name);
 
-                $message->cc('cc@johndoe.com', 'CC Name');
-                $message->bcc('bcc@johndoe.com', 'BCC Name');
+            $message->cc('cc@johndoe.com', 'CC Name');
+            $message->bcc('bcc@johndoe.com', 'BCC Name');
 
-                $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
+            $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
 
-                $message->subject('This is the test subject');
+            $message->subject('This is the test subject');
 
-                $message->priority(3);
-            });
-        } catch (TransportException $e) {
-
-        }
+            $message->priority(3);
+        });
 
         $this->assertDatabaseHas('sent_emails', [
             'hash'            => 'random-hash',
@@ -282,10 +263,7 @@ class MailTrackerTest extends SetUpTest
             'mime' => 'application/pdf',
         ]);
 
-        try {
-            Mail::to($email)->send($mailable);
-        } catch (Exception $e) {
-        }
+        Mail::to($email)->send($mailable);
 
         $this->assertDatabaseHas('sent_emails', [
             'hash'            => 'random-hash',
@@ -304,27 +282,25 @@ class MailTrackerTest extends SetUpTest
         $subject      = $faker->sentence;
         $name         = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
-        try {
-            Mail::send('email.test', [], function ($message) use ($email, $anotherEmail, $subject, $name) {
-                $message->from('from@johndoe.com', 'From Name');
-                $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->to($email, $name);
-                $message->to($anotherEmail, $name);
+        Mail::send('email.test', [], function ($message) use ($email, $anotherEmail, $subject, $name) {
+            $message->from('from@johndoe.com', 'From Name');
+            $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->cc('cc@johndoe.com', 'CC Name');
-                $message->bcc('bcc@johndoe.com', 'BCC Name');
+            $message->to($email, $name);
+            $message->to($anotherEmail, $name);
 
-                $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
+            $message->cc('cc@johndoe.com', 'CC Name');
+            $message->bcc('bcc@johndoe.com', 'BCC Name');
 
-                $message->subject($subject);
+            $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
 
-                $message->priority(3);
+            $message->subject($subject);
 
-                $message->getHeaders()->addTextHeader('X-No-Track', Str::random(10));
-            });
-        } catch (TransportException $e) {
-        }
+            $message->priority(3);
+
+            $message->getHeaders()->addTextHeader('X-No-Track', Str::random(10));
+        });
 
         $this->assertDatabaseMissing('sent_emails', [
             'subject'         => $subject,
@@ -974,26 +950,24 @@ class MailTrackerTest extends SetUpTest
         $name        = $faker->firstName . ' ' . $faker->lastName;
         $header_test = Str::random(10);
         \View::addLocation(__DIR__);
-        try {
-            \Mail::send('email.test', [], function ($message) use ($email, $subject, $name, $header_test) {
-                $message->from('from@johndoe.com', 'From Name');
-                $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->to($email, $name);
+        \Mail::send('email.test', [], function ($message) use ($email, $subject, $name, $header_test) {
+            $message->from('from@johndoe.com', 'From Name');
+            $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->cc('cc@johndoe.com', 'CC Name');
-                $message->bcc('bcc@johndoe.com', 'BCC Name');
+            $message->to($email, $name);
 
-                $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
+            $message->cc('cc@johndoe.com', 'CC Name');
+            $message->bcc('bcc@johndoe.com', 'BCC Name');
 
-                $message->subject($subject);
+            $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
 
-                $message->priority(3);
+            $message->subject($subject);
 
-                $message->getHeaders()->addTextHeader('X-Header-Test', $header_test);
-            });
-        } catch (TransportException $e) {
-        }
+            $message->priority(3);
+
+            $message->getHeaders()->addTextHeader('X-Header-Test', $header_test);
+        });
 
         $track = MailTracker::sentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
         $this->assertEquals($header_test, $track->getHeader('X-Header-Test'));
@@ -1010,26 +984,24 @@ class MailTrackerTest extends SetUpTest
         $name        = $faker->firstName . ' ' . $faker->lastName;
         $header_test = Str::random(100) . ', ' . Str::random(100) . ', ' . Str::random(100);
         View::addLocation(__DIR__);
-        try {
-            Mail::send('email.test', [], function ($message) use ($email, $subject, $name, $header_test) {
-                $message->from('from@johndoe.com', 'From Name');
-                $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->to($email, $name);
+        Mail::send('email.test', [], function ($message) use ($email, $subject, $name, $header_test) {
+            $message->from('from@johndoe.com', 'From Name');
+            $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->cc('cc@johndoe.com', 'CC Name');
-                $message->bcc('bcc@johndoe.com', 'BCC Name');
+            $message->to($email, $name);
 
-                $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
+            $message->cc('cc@johndoe.com', 'CC Name');
+            $message->bcc('bcc@johndoe.com', 'BCC Name');
 
-                $message->subject($subject);
+            $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
 
-                $message->priority(3);
+            $message->subject($subject);
 
-                $message->getHeaders()->addTextHeader('X-Header-Test', $header_test);
-            });
-        } catch (TransportException $e) {
-        }
+            $message->priority(3);
+
+            $message->getHeaders()->addTextHeader('X-Header-Test', $header_test);
+        });
 
         $track = MailTracker::sentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
         $this->assertEquals($header_test, $track->getHeader('X-Header-Test'));
@@ -1045,32 +1017,30 @@ class MailTrackerTest extends SetUpTest
         $subject = $faker->sentence;
         $name    = $faker->firstName . ' ' . $faker->lastName;
         View::addLocation(__DIR__);
-        try {
-            Mail::send('email.test', [], function ($message) use ($email, $subject, $name) {
-                $message->from('from@johndoe.com', 'From Name');
-                $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->to($email, $name);
+        Mail::send('email.test', [], function ($message) use ($email, $subject, $name) {
+            $message->from('from@johndoe.com', 'From Name');
+            $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->cc('cc.averylongemail1@johndoe.com', 'CC This Person With a Long Name 1');
-                $message->cc('cc.averylongemail2@johndoe.com', 'CC This Person With a Long Name 2');
-                $message->cc('cc.averylongemail3@johndoe.com', 'CC This Person With a Long Name 3');
-                $message->cc('cc.averylongemail4@johndoe.com', 'CC This Person With a Long Name 4');
-                $message->cc('cc.averylongemail5@johndoe.com', 'CC This Person With a Long Name 5');
-                $message->cc('cc.averylongemail6@johndoe.com', 'CC This Person With a Long Name 6');
-                $message->cc('cc.averylongemail7@johndoe.com', 'CC This Person With a Long Name 7');
-                $message->cc('cc.averylongemail8@johndoe.com', 'CC This Person With a Long Name 8');
-                $message->cc('cc.averylongemail9@johndoe.com', 'CC This Person With a Long Name 9');
-                $message->bcc('bcc@johndoe.com', 'BCC Name');
+            $message->to($email, $name);
 
-                $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
+            $message->cc('cc.averylongemail1@johndoe.com', 'CC This Person With a Long Name 1');
+            $message->cc('cc.averylongemail2@johndoe.com', 'CC This Person With a Long Name 2');
+            $message->cc('cc.averylongemail3@johndoe.com', 'CC This Person With a Long Name 3');
+            $message->cc('cc.averylongemail4@johndoe.com', 'CC This Person With a Long Name 4');
+            $message->cc('cc.averylongemail5@johndoe.com', 'CC This Person With a Long Name 5');
+            $message->cc('cc.averylongemail6@johndoe.com', 'CC This Person With a Long Name 6');
+            $message->cc('cc.averylongemail7@johndoe.com', 'CC This Person With a Long Name 7');
+            $message->cc('cc.averylongemail8@johndoe.com', 'CC This Person With a Long Name 8');
+            $message->cc('cc.averylongemail9@johndoe.com', 'CC This Person With a Long Name 9');
+            $message->bcc('bcc@johndoe.com', 'BCC Name');
 
-                $message->subject($subject);
+            $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
 
-                $message->priority(3);
-            });
-        } catch (TransportException $e) {
-        }
+            $message->subject($subject);
+
+            $message->priority(3);
+        });
 
         $track = MailTracker::sentEmailModel()->newQuery()->orderBy('id', 'desc')->first();
 
@@ -1119,24 +1089,22 @@ class MailTrackerTest extends SetUpTest
         $subject = $faker->sentence;
         $name    = $faker->firstName . ' ' . $faker->lastName;
         \View::addLocation(__DIR__);
-        try {
-            \Mail::send('email.test', [], function ($message) use ($email, $subject, $name) {
-                $message->from('from@johndoe.com', 'From Name');
-                $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->to($email, $name);
+        \Mail::send('email.test', [], function ($message) use ($email, $subject, $name) {
+            $message->from('from@johndoe.com', 'From Name');
+            $message->sender('sender@johndoe.com', 'Sender Name');
 
-                $message->cc('cc@johndoe.com', 'CC Name');
-                $message->bcc('bcc@johndoe.com', 'BCC Name');
+            $message->to($email, $name);
 
-                $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
+            $message->cc('cc@johndoe.com', 'CC Name');
+            $message->bcc('bcc@johndoe.com', 'BCC Name');
 
-                $message->subject($subject);
+            $message->replyTo('reply-to@johndoe.com', 'Reply-To Name');
 
-                $message->priority(3);
-            });
-        } catch (TransportException $e) {
-        }
+            $message->subject($subject);
+
+            $message->priority(3);
+        });
 
         Event::assertDispatched(EmailSentEvent::class);
 
@@ -1214,14 +1182,11 @@ class MailTrackerTest extends SetUpTest
 
         Storage::fake(config('mail-tracker.tracker-filesystem'));
 
-        try {
-            Mail::raw($content, function ($message) use ($email, $name) {
-                $message->from('from@johndoe.com', 'From Name');
+        Mail::raw($content, function ($message) use ($email, $name) {
+            $message->from('from@johndoe.com', 'From Name');
 
-                $message->to($email, $name);
-            });
-        } catch (Exception $e) {
-        }
+            $message->to($email, $name);
+        });
 
         $this->assertDatabaseHas('sent_emails', [
             'hash'            => 'random-hash',

--- a/tests/SetUpTest.php
+++ b/tests/SetUpTest.php
@@ -59,6 +59,7 @@ abstract class SetUpTest extends TestCase
             'secret' => 'aws-secret',
         ]);
         $app['config']->set('mail.from.address', 'test@example.com');
+        $app['config']->set('mail.default', 'log');
         $app['config']->set('app.debug', true);
     }
 }


### PR DESCRIPTION
Thought i'd just post this as a possible route to fix the redirect hijacking stuff. 

The introduction of signedRoutes but with a grace period should allow people to migrate to this form of the product with relative ease. 

Mostly posting this to gauge your opinion @jdavidbakr 

The current solution where for EVERY click of a link the system is potentially pulling the Content from a filesystem to check whether the domains in it are valid is cumbersome and alot of extra strain on the system. If we can switch to the fact that signedRoutes make sure that the links are created by code on the sending of the email should enforce all the things we need from a security point of view. 

But please let me know your thoughts. 

I also dropped lumen as it's dead and the lumen docs actively tell people not to use it. 

I also cleaned up some legacy stuff that's not getting called anymore from any of the code